### PR TITLE
Solve issue concern slave reliability during i2c response

### DIFF
--- a/avr/libraries/Wire/src/utility/twi.c
+++ b/avr/libraries/Wire/src/utility/twi.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* © 2018 Microchip Technology Inc. and its subsidiaries.
+* Â© 2018 Microchip Technology Inc. and its subsidiaries.
 * 
 * Subject to your compliance with these terms, you may use Microchip software 
 * and any derivatives exclusively with Microchip products. It is your 
@@ -577,9 +577,6 @@ void TWI_SlaveInterruptHandler(){
 void TWI_SlaveAddressMatchHandler(){
 	slave_trans_status = TWIS_STATUS_BUSY;
 	slave_result = TWIS_RESULT_UNKNOWN;
-	
-	/* Disable address & stop interrupt */
-	TWI0.SCTRLA &= ~(TWI_APIEN_bm | TWI_PIEN_bm);
 	
 	/* Send ACK, wait for data interrupt */
 	TWI0.SCTRLB = TWI_SCMD_RESPONSE_gc;	


### PR DESCRIPTION
line 582: ```TWI0.SCTRLA &= ~(TWI_APIEN_bm | TWI_PIEN_bm); ```

This line makes that interrupts are disabled during master i2cdetect procedure and no return to interruption is possible when i2c error transmission occur.

In my case, the sketch and the i2c line crashes (SDA and SCL low level permanently) after about 48 hours of interrogation of the slave (alls 200ms of write / read cycles).

For the moment, after 50h of test, I have not noticed an edge effect to delete this line (remains the case of the multi-master who has not been tested).

Credit for the localization of the problem: @facchinm