### PR TITLE
Update programmers.txt

### DIFF
--- a/megaavr/programmers.txt
+++ b/megaavr/programmers.txt
@@ -18,3 +18,10 @@ edbg.protocol=xplainedpro_updi
 edbg.program.protocol=xplainedpro_updi
 edbg.program.tool=avrdude
 edbg.program.extra_params=-Pusb
+
+atmelice_updi.name=Atmel-ICE (UPDI)
+atmelice_updi.communication=usb
+atmelice_updi.protocol=atmelice_updi
+atmelice_updi.program.protocol=jtagice3_updi
+atmelice_updi.program.tool=avrdude
+atmelice_updi.program.extra_params=-Pusb


### PR DESCRIPTION
Add support for Atmel-ICE (UPDI). Tested ability to program in Arduino 1.8.9 with a custom atmega4808 board. Not entirely sure why "atmelice_updi.protocol=atmelice_updi" and "atmelice_updi.program.protocol=jtagice3_updi" but consistent values didn't work.