### PR TITLE
Timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ ATmega3208, ATmega4808, ATmega3209 and ATmega4809.
 * [BOD option](#bod-option)
 * [Reset pin](#reset-pin)
 * [Pinout](#pinout)
+* [Pin swaps](#pin-swaps)
+* [PWM output](#pwm-output)
 * [How to install](#how-to-install)
   - [Boards Manager Installation](#boards-manager-installation)
   - [Manual Installation](#manual-installation)
@@ -104,6 +106,57 @@ Please have a look at the pins_arduino.h files for detailed info.<br/> <br/>
 | **MegaCoreX ATmega3209/4809 pinout**                                                                              | **MegaCoreX ATmega3208/4808 pinout**                                                                                                                 |
 |-------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 |<img src="https://i.imgur.com/q2wB2OW.jpg" width="350"><br/><img src="https://i.imgur.com/7GcHjqk.jpg" width="350">|<img src="https://i.imgur.com/ZaCM75c.jpg" width="350"><br/><img src="https://i.imgur.com/BPg75ib.jpg" width="350"><br/><br/><br/><br/><br/><br/><br/>|
+
+
+## Pin swaps
+The megaAVR-0 microcontrollers has some capabilities to swap pins for some of the built in devices. 
+This is specified by invoking the `pins()` method before the `begin()`.
+The `pins()` method will return `true` if the pin combination is supported.
+For `Serial` the method is `pins(tx,rx)`. This is the same pin sequence as used for the
+ESP8266 `pins` method, but the opposite of the one SoftwareSerial uses.
+For `Wire` the method is `pins(sda,scl)`, and for `SPI` it is `pins(mosi,miso,scl,ss)`.
+
+Available pin swaps for the *48 pin standard* pinout are:
+
+| Device    | Default              | Alternative 1        | Alternative 2        |
+|-----------|----------------------|----------------------|----------------------|
+| `Serial`  | `pins(0,1)`          | `pins(4,5)`          |                      |
+| `Wire`    | `pins(2,3)`          | `pins(16,17)`        |                      |
+| `SPI`     | `pins(4,5,6,7)`      | `pins(14,15,16,17)`  | `pins(30,31,32,33)`  |
+| `Serial3` | `pins(8,9)`          | `pins(12,13)`        |                      |
+| `Serial1` | `pins(12,13)`        | `pins(14,15)`        |                      |
+| `Serial2` | `pins(32,35)`        | `pins(38,39)`        |                      |
+
+Available pin swaps for the *28 pin* and *32 pin standard* pinouts are:
+
+| Device    | Default              | Alternative          |
+|-----------|----------------------|----------------------|
+| `Serial`  | `pins(0,1)`          | `pins(4,5)`          |
+| `Wire`    | `pins(2,3)`          | `pins(10,11)`        |
+| `SPI`     | `pins(4,5,6,7)`      | `pins(8,9,10,11)`    |
+| `Serial1` | `pins(8,9)`          |                      |
+| `Serial2` | `pins(20,21)`        | `pins(24,25)`        |
+
+Available pin swaps for the *Uno WiFi* pinout are:
+
+| Device    | Default              | Alternative          |
+|-----------|----------------------|----------------------|
+| `Serial1` | `pins(1,0)`          | `pins(32,33)`        |
+| `Wire`    | `pins(20,21)`        |                      |
+| `Serial2` | `pins(24,23)`        | `pins(2,7)`          |
+| `Serial`  | `pins(27,26)`        | `pins(9,10)`         |
+| `SPI`     | `pins(32,33,34,10)`  |                      |
+
+
+## PWM output
+PWM output, `analogWrite()`, is available for the following pins:
+
+| Pinout            | Available PWM pins      |
+|-------------------|-------------------------|
+| *28 pin standard* | 8,9,10,11               |
+| *32 pin standard* | 8,9,10,11,24,25         |
+| *48 pin standard* | 14,15,16,17,18,19,38,39 |
+| *Uno WiFi*        | 3,5,6,9,10              |
 
 
 ## How to install

--- a/megaavr/cores/coreX-corefiles/wiring_digital.c
+++ b/megaavr/cores/coreX-corefiles/wiring_digital.c
@@ -79,7 +79,8 @@ void pinMode(uint8_t pin, PinMode mode)
 // user than calling. (It will take more bytes on the 168.)
 //
 // But shouldn't this be moved into pinMode? Seems silly to check and do on
-// each digitalread or write.
+// each digitalread or write. One issue that then needs to be fixed is that
+// current implementation on analogWrite() depends on this behaviour.
 //
 // Mark Sproul:
 // - Removed inline. Save 170 bytes on atmega1280
@@ -107,7 +108,8 @@ static void turnOffPWM(uint8_t pin)
 		bit_pos = digitalPinToBitPosition(pin);
 
 		/* Disable corresponding channel */
-		TCA0.SINGLE.CTRLB &= ~(1 << (TCA_SINGLE_CMP0EN_bp + bit_pos));
+		if (bit_pos >= 3) ++bit_pos; /* Upper 3 bits are shifted by 1 */
+		TCA0.SPLIT.CTRLB &= ~(1 << (TCA_SPLIT_LCMP0EN_bp + bit_pos));
 
 		break;
 

--- a/megaavr/variants/28pin-standard/pins_arduino.h
+++ b/megaavr/variants/28pin-standard/pins_arduino.h
@@ -33,7 +33,7 @@
 
 #define EXTERNAL_NUM_INTERRUPTS     (NUM_TOTAL_PINS)
 
-#define digitalPinHasPWM(p)         ((p) == 10 || (p) == 11)
+#define digitalPinHasPWM(p)         ((p) >= 8 && (p) <= 11)
 
 // SPI 0
 // No pinswap by default
@@ -142,8 +142,8 @@ const uint8_t PROGMEM digital_pin_to_port[] = {
   PA, //  5 PA5/MISO
   PA, //  6 PA6/SCK
   PA, //  7 PA7/SS/CLKOUT
-  PC, //  8 PC0/USART1_Tx
-  PC, //  9 PC1/USART1_Rx
+  PC, //  8 PC0/USART1_Tx/TCA0 PWM
+  PC, //  9 PC1/USART1_Rx/TCA0 PWM
   PC, // 10 PC2/TCA0 PWM
   PC, // 11 PC3/TCA0 PWM
   PD, // 12 PD0/AIN0
@@ -169,8 +169,8 @@ const uint8_t PROGMEM digital_pin_to_bit_position[] = {
   PIN5_bp, //  5 PA5/MISO
   PIN6_bp, //  6 PA6/SCK
   PIN7_bp, //  7 PA7/SS/CLKOUT
-  PIN0_bp, //  8 PC0/USART1_Tx
-  PIN1_bp, //  9 PC1/USART1_Rx
+  PIN0_bp, //  8 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bp, //  9 PC1/USART1_Rx/TCA0 PWM
   PIN2_bp, // 10 PC2/TCA0 PWM
   PIN3_bp, // 11 PC3/TCA0 PWM
   PIN0_bp, // 12 PD0/AIN0
@@ -196,8 +196,8 @@ const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
   PIN5_bm, //  5 PA5/MISO
   PIN6_bm, //  6 PA6/SCK
   PIN7_bm, //  7 PA7/SS/CLKOUT
-  PIN0_bm, //  8 PC0/USART1_Tx
-  PIN1_bm, //  9 PC1/USART1_Rx
+  PIN0_bm, //  8 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bm, //  9 PC1/USART1_Rx/TCA0 PWM
   PIN2_bm, // 10 PC2/TCA0 PWM
   PIN3_bm, // 11 PC3/TCA0 PWM
   PIN0_bm, // 12 PD0/AIN0
@@ -222,8 +222,8 @@ const uint8_t PROGMEM digital_pin_to_timer[] = {
   NOT_ON_TIMER, //  5 PA5/MISO
   NOT_ON_TIMER, //  6 PA6/SCK
   NOT_ON_TIMER, //  7 PA7/SS/CLKOUT
-  NOT_ON_TIMER, //  8 PC0/USART1_Tx
-  NOT_ON_TIMER, //  9 PC1/USART1_Rx
+  TIMERA0,      //  8 PC0/USART1_Tx/TCA0 PWM
+  TIMERA0,      //  9 PC1/USART1_Rx/TCA0 PWM
   TIMERA0,      // 10 PC2/TCA0 PWM
   TIMERA0,      // 11 PC3/TCA0 PWM
   NOT_ON_TIMER, // 12 PD0/AIN0

--- a/megaavr/variants/28pin-standard/variant.c
+++ b/megaavr/variants/28pin-standard/variant.c
@@ -12,19 +12,23 @@ void setup_timers() {
   // PORTMUX setting for TCA -> outputs [2:3] point to PORTC pins [2:3]
   PORTMUX.TCAROUTEA  = PORTMUX_TCA0_PORTC_gc;
 
-  // Setup timers for single slope PWM, but do not enable, will do in analogWrite()
-  TCA0.SINGLE.CTRLB = TCA_SINGLE_WGMODE_SINGLESLOPE_gc;
+  // Enable split mode before anything else
+  TCA0.SPLIT.CTRLD = TCA_SINGLE_SPLITM_bm;
 
-  // Period setting, 16 bit register but val resolution is 8 bit
-  TCA0.SINGLE.PER = PWM_TIMER_PERIOD;
+  // Period setting, two 8 bit registers
+  TCA0.SPLIT.LPER =
+  TCA0.SPLIT.HPER = PWM_TIMER_PERIOD;
 
   // Default duty 50%, will re-assign in analogWrite()
-  TCA0.SINGLE.CMP0BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP1BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP2BUF = PWM_TIMER_COMPARE;
+  TCA0.SPLIT.LCMP0 =
+  TCA0.SPLIT.LCMP1 =
+  TCA0.SPLIT.LCMP2 =
+  TCA0.SPLIT.HCMP0 =
+  TCA0.SPLIT.HCMP1 =
+  TCA0.SPLIT.HCMP2 = PWM_TIMER_COMPARE;
 
   // Use DIV64 prescaler (giving 250kHz clock), enable TCA timer
-  TCA0.SINGLE.CTRLA = (TCA_SINGLE_CLKSEL_DIV64_gc) | (TCA_SINGLE_ENABLE_bm);
+  TCA0.SPLIT.CTRLA = (TCA_SPLIT_CLKSEL_DIV64_gc) | (TCA_SPLIT_ENABLE_bm);
 
   //  TYPE B TIMERS 
   
@@ -109,6 +113,8 @@ FORCE_INLINE bool isDoubleBondedActive(uint8_t pin) {
   /* Special check for SPI_SS double bonded pin -- no action if SPI is active 
     (Using SPI Enable bit as indicator of SPI activity) */
   //if((pin == 10) && (SPI0.CTRLA & SPI_ENABLE_bm)) return true;
+
+  // May check Serial1 that may conflict with A-timers (swapped or not)
 
   return false;
 }

--- a/megaavr/variants/32pin-standard/pins_arduino.h
+++ b/megaavr/variants/32pin-standard/pins_arduino.h
@@ -33,7 +33,7 @@
 
 #define EXTERNAL_NUM_INTERRUPTS     (NUM_TOTAL_PINS)
 
-#define digitalPinHasPWM(p)         ((p) == 10 || (p) == 11 || (p) == 24 || (p) == 25)
+#define digitalPinHasPWM(p)         (((p) >= 8 && (p) <= 11) || (p) == 24 || (p) == 25)
 
 // SPI 0
 // No pinswap enabled by default
@@ -150,8 +150,8 @@ const uint8_t PROGMEM digital_pin_to_port[] = {
   PA, //  5 PA5/MISO
   PA, //  6 PA6/SCK
   PA, //  7 PA7/SS/CLKOUT
-  PC, //  8 PC0/USART1_Tx
-  PC, //  9 PC1/USART1_Rx
+  PC, //  8 PC0/USART1_Tx/TCA0 PWM
+  PC, //  9 PC1/USART1_Rx/TCA0 PWM
   PC, // 10 PC2/TCA0 PWM
   PC, // 11 PC3/TCA0 PWM
   PD, // 12 PD0/AIN0
@@ -181,8 +181,8 @@ const uint8_t PROGMEM digital_pin_to_bit_position[] = {
   PIN5_bp, //  5 PA5/MISO
   PIN6_bp, //  6 PA6/SCK
   PIN7_bp, //  7 PA7/SS/CLKOUT
-  PIN0_bp, //  8 PC0/USART1_Tx
-  PIN1_bp, //  9 PC1/USART1_Rx
+  PIN0_bp, //  8 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bp, //  9 PC1/USART1_Rx/TCA0 PWM
   PIN2_bp, // 10 PC2/TCA0 PWM
   PIN3_bp, // 11 PC3/TCA0 PWM
   PIN0_bp, // 12 PD0/AIN0
@@ -212,8 +212,8 @@ const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
   PIN5_bm, //  5 PA5/MISO
   PIN6_bm, //  6 PA6/SCK
   PIN7_bm, //  7 PA7/SS/CLKOUT
-  PIN0_bm, //  8 PC0/USART1_Tx
-  PIN1_bm, //  9 PC1/USART1_Rx
+  PIN0_bm, //  8 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bm, //  9 PC1/USART1_Rx/TCA0 PWM
   PIN2_bm, // 10 PC2/TCA0 PWM
   PIN3_bm, // 11 PC3/TCA0 PWM
   PIN0_bm, // 12 PD0/AIN0
@@ -242,8 +242,8 @@ const uint8_t PROGMEM digital_pin_to_timer[] = {
   NOT_ON_TIMER, //  5 PA5/MISO
   NOT_ON_TIMER, //  6 PA6/SCK
   NOT_ON_TIMER, //  7 PA7/SS/CLKOUT
-  NOT_ON_TIMER, //  8 PC0/USART1_Tx
-  NOT_ON_TIMER, //  9 PC1/USART1_Rx
+  TIMERA0,      //  8 PC0/USART1_Tx/TCA0 PWM
+  TIMERA0,      //  9 PC1/USART1_Rx/TCA0 PWM
   TIMERA0,      // 10 PC2/TCA0 PWM
   TIMERA0,      // 11 PC3/TCA0 PWM
   NOT_ON_TIMER, // 12 PD0/AIN0

--- a/megaavr/variants/32pin-standard/variant.c
+++ b/megaavr/variants/32pin-standard/variant.c
@@ -12,19 +12,23 @@ void setup_timers() {
   // PORTMUX setting for TCA -> outputs [2:3] point to PORTC pins [2:3]
   PORTMUX.TCAROUTEA  = PORTMUX_TCA0_PORTC_gc;
 
-  // Setup timers for single slope PWM, but do not enable, will do in analogWrite()
-  TCA0.SINGLE.CTRLB = TCA_SINGLE_WGMODE_SINGLESLOPE_gc;
+  // Enable split mode before anything else
+  TCA0.SPLIT.CTRLD = TCA_SINGLE_SPLITM_bm;
 
-  // Period setting, 16 bit register but val resolution is 8 bit
-  TCA0.SINGLE.PER = PWM_TIMER_PERIOD;
+  // Period setting, two 8 bit registers
+  TCA0.SPLIT.LPER =
+  TCA0.SPLIT.HPER = PWM_TIMER_PERIOD;
 
   // Default duty 50%, will re-assign in analogWrite()
-  TCA0.SINGLE.CMP0BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP1BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP2BUF = PWM_TIMER_COMPARE;
+  TCA0.SPLIT.LCMP0 =
+  TCA0.SPLIT.LCMP1 =
+  TCA0.SPLIT.LCMP2 =
+  TCA0.SPLIT.HCMP0 =
+  TCA0.SPLIT.HCMP1 =
+  TCA0.SPLIT.HCMP2 = PWM_TIMER_COMPARE;
 
   // Use DIV64 prescaler (giving 250kHz clock), enable TCA timer
-  TCA0.SINGLE.CTRLA = (TCA_SINGLE_CLKSEL_DIV64_gc) | (TCA_SINGLE_ENABLE_bm);
+  TCA0.SPLIT.CTRLA = (TCA_SPLIT_CLKSEL_DIV64_gc) | (TCA_SPLIT_ENABLE_bm);
 
   //  TYPE B TIMERS 
   
@@ -109,6 +113,8 @@ FORCE_INLINE bool isDoubleBondedActive(uint8_t pin) {
   /* Special check for SPI_SS double bonded pin -- no action if SPI is active 
     (Using SPI Enable bit as indicator of SPI activity) */
   //if((pin == 10) && (SPI0.CTRLA & SPI_ENABLE_bm)) return true;
+
+  // May check Serial1 that may conflict with A-timers (swapped or not)
 
   return false;
 }

--- a/megaavr/variants/48pin-standard/pins_arduino.h
+++ b/megaavr/variants/48pin-standard/pins_arduino.h
@@ -38,7 +38,7 @@
 
 #define EXTERNAL_NUM_INTERRUPTS     (NUM_TOTAL_PINS)
 
-#define digitalPinHasPWM(p)         ((p) == 16 || (p) == 17 || (p) == 18 || (p) == 19 || (p) == 38 || (p) == 39)
+#define digitalPinHasPWM(p)         (((p) >= 14 && (p) <= 19) || (p) == 38 || (p) == 39)
 
 // SPI 0
 // No pinswap enabled by default
@@ -183,8 +183,8 @@ const uint8_t PROGMEM digital_pin_to_port[] = {
   PB, // 11 PB3
   PB, // 12 PB4
   PB, // 13 PB5
-  PC, // 14 PC0/USART1_Tx
-  PC, // 15 PC1/USART1_Rx
+  PC, // 14 PC0/USART1_Tx/TCA0 PWM
+  PC, // 15 PC1/USART1_Rx/TCA0 PWM
   PC, // 16 PC2/TCA0 PWM
   PC, // 17 PC3/TCA0 PWM
   PC, // 18 PC4/TCA0 PWM
@@ -228,8 +228,8 @@ const uint8_t PROGMEM digital_pin_to_bit_position[] = {
   PIN3_bp, // 11 PB3
   PIN4_bp, // 12 PB4
   PIN5_bp, // 13 PB5
-  PIN0_bp, // 14 PC0/USART1_Tx
-  PIN1_bp, // 15 PC1/USART1_Rx
+  PIN0_bp, // 14 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bp, // 15 PC1/USART1_Rx/TCA0 PWM
   PIN2_bp, // 16 PC2/TCA0 PWM
   PIN3_bp, // 17 PC3/TCA0 PWM
   PIN4_bp, // 18 PC4/TCA0 PWM
@@ -273,8 +273,8 @@ const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
   PIN3_bm, // 11 PB3
   PIN4_bm, // 12 PB4
   PIN5_bm, // 13 PB5
-  PIN0_bm, // 14 PC0/USART1_Tx
-  PIN1_bm, // 15 PC1/USART1_Rx
+  PIN0_bm, // 14 PC0/USART1_Tx/TCA0 PWM
+  PIN1_bm, // 15 PC1/USART1_Rx/TCA0 PWM
   PIN2_bm, // 16 PC2/TCA0 PWM
   PIN3_bm, // 17 PC3/TCA0 PWM
   PIN4_bm, // 18 PC4/TCA0 PWM
@@ -317,8 +317,8 @@ const uint8_t PROGMEM digital_pin_to_timer[] = {
   NOT_ON_TIMER, // 11 PB3
   NOT_ON_TIMER, // 12 PB4
   NOT_ON_TIMER, // 13 PB5
-  NOT_ON_TIMER, // 14 PC0/USART1_Tx
-  NOT_ON_TIMER, // 15 PC1/USART1_Rx
+  TIMERA0,      // 14 PC0/USART1_Tx/TCA0 PWM
+  TIMERA0,      // 15 PC1/USART1_Rx/TCA0 PWM
   TIMERA0,      // 16 PC2/TCA0 PWM
   TIMERA0,      // 17 PC3/TCA0 PWM
   TIMERA0,      // 18 PC4/TCA0 PWM

--- a/megaavr/variants/48pin-standard/variant.c
+++ b/megaavr/variants/48pin-standard/variant.c
@@ -12,19 +12,23 @@ void setup_timers() {
   // PORTMUX setting for TCA -> outputs [2:5] point to PORTC pins [2:5]
   PORTMUX.TCAROUTEA  = PORTMUX_TCA0_PORTC_gc;
 
-  // Setup timers for single slope PWM, but do not enable, will do in analogWrite()
-  TCA0.SINGLE.CTRLB = TCA_SINGLE_WGMODE_SINGLESLOPE_gc;
+  // Enable split mode before anything else
+  TCA0.SPLIT.CTRLD = TCA_SINGLE_SPLITM_bm;
 
-  // Period setting, 16 bit register but val resolution is 8 bit
-  TCA0.SINGLE.PER = PWM_TIMER_PERIOD;
+  // Period setting, two 8 bit registers
+  TCA0.SPLIT.LPER =
+  TCA0.SPLIT.HPER = PWM_TIMER_PERIOD;
 
   // Default duty 50%, will re-assign in analogWrite()
-  TCA0.SINGLE.CMP0BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP1BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP2BUF = PWM_TIMER_COMPARE;
+  TCA0.SPLIT.LCMP0 =
+  TCA0.SPLIT.LCMP1 =
+  TCA0.SPLIT.LCMP2 =
+  TCA0.SPLIT.HCMP0 =
+  TCA0.SPLIT.HCMP1 =
+  TCA0.SPLIT.HCMP2 = PWM_TIMER_COMPARE;
 
   // Use DIV64 prescaler (giving 250kHz clock), enable TCA timer
-  TCA0.SINGLE.CTRLA = (TCA_SINGLE_CLKSEL_DIV64_gc) | (TCA_SINGLE_ENABLE_bm);
+  TCA0.SPLIT.CTRLA = (TCA_SPLIT_CLKSEL_DIV64_gc) | (TCA_SPLIT_ENABLE_bm);
 
   //  TYPE B TIMERS 
   
@@ -109,6 +113,8 @@ FORCE_INLINE bool isDoubleBondedActive(uint8_t pin) {
   /* Special check for SPI_SS double bonded pin -- no action if SPI is active 
     (Using SPI Enable bit as indicator of SPI activity) */
   //if((pin == 10) && (SPI0.CTRLA & SPI_ENABLE_bm)) return true;
+
+  // May check Serial1 that may conflict with A-timers (swapped or not)
 
   return false;
 }

--- a/megaavr/variants/uno-wifi/variant.c
+++ b/megaavr/variants/uno-wifi/variant.c
@@ -12,19 +12,23 @@ void setup_timers() {
   // PORTMUX setting for TCA -> all outputs [0:2] point to PORTB pins [0:2]
   PORTMUX.TCAROUTEA  = PORTMUX_TCA0_PORTB_gc;
 
-  // Setup timers for single slope PWM, but do not enable, will do in analogWrite()
-  TCA0.SINGLE.CTRLB = TCA_SINGLE_WGMODE_SINGLESLOPE_gc;
+  // Enable split mode before anything else
+  TCA0.SPLIT.CTRLD = TCA_SINGLE_SPLITM_bm;
 
-  // Period setting, 16 bit register but val resolution is 8 bit
-  TCA0.SINGLE.PER = PWM_TIMER_PERIOD;
+  // Period setting, two 8 bit registers
+  TCA0.SPLIT.LPER =
+  TCA0.SPLIT.HPER = PWM_TIMER_PERIOD;
 
   // Default duty 50%, will re-assign in analogWrite()
-  TCA0.SINGLE.CMP0BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP1BUF = PWM_TIMER_COMPARE;
-  TCA0.SINGLE.CMP2BUF = PWM_TIMER_COMPARE;
+  TCA0.SPLIT.LCMP0 =
+  TCA0.SPLIT.LCMP1 =
+  TCA0.SPLIT.LCMP2 =
+  TCA0.SPLIT.HCMP0 =
+  TCA0.SPLIT.HCMP1 =
+  TCA0.SPLIT.HCMP2 = PWM_TIMER_COMPARE;
 
   // Use DIV64 prescaler (giving 250kHz clock), enable TCA timer
-  TCA0.SINGLE.CTRLA = (TCA_SINGLE_CLKSEL_DIV64_gc) | (TCA_SINGLE_ENABLE_bm);
+  TCA0.SPLIT.CTRLA = (TCA_SPLIT_CLKSEL_DIV64_gc) | (TCA_SPLIT_ENABLE_bm);
 
   //  TYPE B TIMERS 
   
@@ -109,6 +113,8 @@ FORCE_INLINE bool isDoubleBondedActive(uint8_t pin) {
   /* Special check for SPI_SS double bonded pin -- no action if SPI is active 
     (Using SPI Enable bit as indicator of SPI activity) */
   //if((pin == 10) && (SPI0.CTRLA & SPI_ENABLE_bm)) return true;
+
+  // May check Serial3 that may conflict with A-timers
 
   return false;
 }


### PR DESCRIPTION
Change mode of timer A from SINGLE to SPLIT so that we can support up to 6 PWM channels on timer A. Importantly, this fixes the bug re. non-operational PWM outputs. Also added optional PWM output on two more pins, which can be used if the corresponding serial channel is not used. 