### PR TITLE
Remove pretty catastrophic loop in the USART serial transmit handler

### DIFF
--- a/megaavr/cores/coreX-corefiles/UART.cpp
+++ b/megaavr/cores/coreX-corefiles/UART.cpp
@@ -107,8 +107,6 @@ void UartClass::_tx_data_empty_irq(void)
 
     (*_hwserial_module).TXDATAL = c;
 
-    while(!((*_hwserial_module).STATUS & USART_DREIF_bm));
-
     if (_tx_buffer_head == _tx_buffer_tail) {
         // Buffer empty, so disable "data register empty" interrupt
         (*_hwserial_module).CTRLA &= (~USART_DREIE_bm);


### PR DESCRIPTION
The new Arduino megaavr serial driver has a serious issue in the transmit interrupt
handler causing tjhe CPU to stay in interrupt handler more or less the entire time
until the character is fully transmitted. Thus blocking out other interrupts,
such as receive on other ports, and also wasting CPU resources.