### PR TITLE
[Logic] Fix vector pointers allocation

### DIFF
--- a/megaavr/libraries/Logic/src/Logic.cpp
+++ b/megaavr/libraries/Logic/src/Logic.cpp
@@ -1,5 +1,8 @@
 #include "Logic.h"
 
+// Array for storing ISR function pointers
+static volatile voidFuncPtr intFuncCCL[4];
+
 // Preinstantiate Object
 CustomLogic Logic;
 

--- a/megaavr/libraries/Logic/src/Logic.h
+++ b/megaavr/libraries/Logic/src/Logic.h
@@ -5,9 +5,6 @@
 
 #include <Arduino.h>
 
-// Array for storing ISR function pointers
-static volatile voidFuncPtr intFuncCCL[4];
-
 //Use in:: when working with logic inputs
 namespace in
 {


### PR DESCRIPTION
Static variables should not be declared in header file, since those variables will be instantiated each compilation units that include the header.