### PR TITLE
[Logic] Separate CCL block instances

### DIFF
--- a/megaavr/libraries/Logic/README.md
+++ b/megaavr/libraries/Logic/README.md
@@ -5,8 +5,8 @@ The megaAVR-0 has four independent internal logic blocks that can be individuall
 More useful information about CCL can be found in the [Microchip Application Note TB3218](http://ww1.microchip.com/downloads/en/AppNotes/TB3218-Getting-Started-with-CCL-90003218A.pdf) and in the [megaAVR-0 family data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/megaAVR0-series-Family-Data-Sheet-DS40002015B.pdf).
 
 
-## block_t
-Struct for interfacing with the built-in logic block. use the predefined objects `block0`, `block1`, `block2` and `block3`.
+## Logic
+Class for interfacing with the built-in logic block. use the predefined objects `Logic0`, `Logic1`, `Logic2` and `Logic3`.
 Each object contains register pointers for interfacing with the right registers. Some of these variables are available to the user.
 
 
@@ -20,11 +20,11 @@ false; // Disable the current logic block
 
 ##### Usage
 ```c++
-Logic.block0.enable = true; // Enable logic block 0
+Logic0.enable = true; // Enable logic block 0
 ```
 
 ##### Default state
-`Logic.block0.enable` defaults to `false` if not specified in the user program.
+`Logic0.enable` defaults to `false` if not specified in the user program.
 
 
 ### input0..input2
@@ -49,13 +49,13 @@ in::tcb;          // Connect input to TCB. Input 0 connects to TCB0 W0, input 1 
 
 ##### Usage
 ``` c++
-Logic.block0.input0 = in::link;  // Connect output from block 1 to input 0 of block 0
-Logic.block0.input1 = in::input; // Connect the input 1 from block 0 to its GPIO
-Logic.block0.input2 = in::input_pullup; // Connect the input 2 from block 0 to its GPIO and enable pullup
+Logic0.input0 = in::link;  // Connect output from block 1 to input 0 of block 0
+Logic0.input1 = in::input; // Connect the input 1 from block 0 to its GPIO
+Logic0.input2 = in::input_pullup; // Connect the input 2 from block 0 to its GPIO and enable pullup
 ```
 
 ##### Default state
-`Logic.blockN.inputN` defaults to `in::unused` if not specified in the user program.
+`LogicN.inputN` defaults to `in::unused` if not specified in the user program.
 
 
 ### output
@@ -68,11 +68,11 @@ out::enable;  // Enable the output GPIO pin
 
 ##### Usage
 ```c++
-Logic.block0.output = out::disable; // Disable the output GPIO pin.
+Logic0.output = out::disable; // Disable the output GPIO pin.
 ```
 
 ##### Default state
-`Logic.blockN.output` defaults to `out::disable` if not specified in the user program.
+`LogicN.output` defaults to `out::disable` if not specified in the user program.
 
 
 ### output_swap
@@ -85,11 +85,11 @@ out::pin_swap; // Use alternative position, pin 6 on the port
 
 ##### Usage
 ```c++
-Logic.block0.output_swap = out::no_swap; // No pin swap for output of block0
+Logic0.output_swap = out::no_swap; // No pin swap for output of block0
 ```
 
 ##### Default state
-`Logic.blockN.output_swap` defaults to `out::no_swap` if not specified in the user program.
+`LogicN.output_swap` defaults to `out::no_swap` if not specified in the user program.
 
 
 ### filter
@@ -103,11 +103,11 @@ filter::filter;       // Connect filter to output
 
 ##### Usage
 ```c++
-Logic.block0.filter = filter::filter; // Enable filter on output of block 0
+Logic0.filter = filter::filter; // Enable filter on output of block 0
 ```
 
 ##### Default state
-`Logic.blockN.filter` defaults to `filter::disable` if not specified in the user program.
+`LogicN.filter` defaults to `filter::disable` if not specified in the user program.
 
 
 ### sequencer
@@ -123,11 +123,11 @@ sequencer::rs_latch;     // RS latch sequencer connected
 
 ##### Usage
 ```c++
-Logic.block0.sequencer = sequencer::disable; // Disable sequencer
+Logic0.sequencer = sequencer::disable; // Disable sequencer
 ```
 
 ##### Default state
-`Logic.blockN.sequencer` defaults to `sequencer::disable` if not specified in the user program.
+`LogicN.sequencer` defaults to `sequencer::disable` if not specified in the user program.
 
 
 ### truth
@@ -136,11 +136,11 @@ Accepted values between 0x00 and 0xFF.
 
 ##### Usage
 ```c++
-Logic.block0.truth = 0xF0;
+Logic0.truth = 0xF0;
 ```
 
 ##### Default state
-`Logic.blockN.truth` defaults to `0x00` if not specified in the user program.
+`LogicN.truth` defaults to `0x00` if not specified in the user program.
 
 
 
@@ -149,8 +149,8 @@ Method for initializing a logic block. The logic block object to initialize is p
 
 ##### Usage
 ```c++
-Logic.init(Logic.block0); // Initialize block 0
-Logic.init(Logic.block1); // Initialize block 1
+Logic0.init(); // Initialize block 0
+Logic1.init(); // Initialize block 1
 ```
 
 
@@ -160,7 +160,7 @@ Method for starting the CCL hardware after all registers have been initialized u
 
 ##### Usage
 ```c++
-Logic.start(); // Start CCL hardware
+Logic::start(); // Start CCL hardware
 ```
 
 
@@ -170,7 +170,7 @@ Method for stopping the CCL hardware.
 
 ##### Usage
 ```c++
-Logic.stop(); // Stop CCL
+Logic::stop(); // Stop CCL
 ```
 
 
@@ -181,7 +181,7 @@ Valid arguments for the third parameters are `RISING`, `FALLING` and `CHANGE`.
 
 ##### Usage
 ```c++
-Logic.attachInterrupt(Logic.block0, blinkLED, RISING); // Runthe blinkLED function when the putput goes high
+Logic0.attachInterrupt(blinkLED, RISING); // Runthe blinkLED function when the putput goes high
 
 void blinkLED()
 {
@@ -196,5 +196,5 @@ Method for disabling interrupts for a specific block.
 
 ##### Usage
 ```c++
-Logic.detachInterrupt(Logic.block0); // Disable interrupts for block 0
+Logic0.detachInterrupt(); // Disable interrupts for block 0
 ```

--- a/megaavr/libraries/Logic/examples/Five_input_NOR/Five_input_NOR.ino
+++ b/megaavr/libraries/Logic/examples/Five_input_NOR/Five_input_NOR.ino
@@ -22,32 +22,32 @@ void setup()
   // Initialize logic block 1
   // Logic block 1 has three inputs, PC0, PC1 and PC2.
   // It's output, PC3 is disabled because we connect the output signal to block 0 internally
-  Logic.block1.enable = true;               // Enable logic block 1
-  Logic.block1.input0 = in::input_pullup;   // Set PC0 as input with pullup
-  Logic.block1.input1 = in::input_pullup;   // Set PC1 as input with pullup
-  Logic.block1.input2 = in::input_pullup;   // Set PC2 as input with pullup
-  Logic.block1.output = out::disable;       // No output on PC3
-  Logic.block1.filter = filter::disable;    // No output filter enabled
-  Logic.block1.truth = 0xFE;                // Set truth table
+  Logic1.enable = true;               // Enable logic block 1
+  Logic1.input0 = in::input_pullup;   // Set PC0 as input with pullup
+  Logic1.input1 = in::input_pullup;   // Set PC1 as input with pullup
+  Logic1.input2 = in::input_pullup;   // Set PC2 as input with pullup
+  Logic1.output = out::disable;       // No output on PC3
+  Logic1.filter = filter::disable;    // No output filter enabled
+  Logic1.truth = 0xFE;                // Set truth table
   
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2. 
   // input2 is internally connected to the output of block1 (which means PA2 is freed up)
   // Block 0 output on PA3
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-  Logic.block0.input2 = in::link;           // Route output from block 1 to this input internally
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0x01;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+  Logic0.input2 = in::link;           // Route output from block 1 to this input internally
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0x01;                // Set truth table
 
   // Initialize logic block 0 and 1
-  Logic.init(Logic.block0);
-  Logic.init(Logic.block1);
+  Logic0.init();
+  Logic1.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Interrupt/Interrupt.ino
+++ b/megaavr/libraries/Logic/examples/Interrupt/Interrupt.ino
@@ -37,22 +37,22 @@ void setup()
   // Initialize logic block 2
   // Logic block 2 has three inputs, PA0, PA1 and PA2.
   // It has one output, but this is disabled because we're using an interrupt instead.
-  Logic.block2.enable = true;               // Enable logic block 0
-  Logic.block2.input0 = in::input_pullup;   // Set PD0 as input with pullup
-  Logic.block2.input1 = in::input_pullup;   // Set PD1 as input with pullup
-  Logic.block2.input2 = in::input_pullup;   // Set PD2 as input with pullup
-  Logic.block2.output = out::disable;       // Disable output on PD3 (we don't have to though)
-  Logic.block2.filter = filter::disable;    // No output filter enabled
-  Logic.block2.truth = 0x01;                // Set truth table
+  Logic2.enable = true;               // Enable logic block 0
+  Logic2.input0 = in::input_pullup;   // Set PD0 as input with pullup
+  Logic2.input1 = in::input_pullup;   // Set PD1 as input with pullup
+  Logic2.input2 = in::input_pullup;   // Set PD2 as input with pullup
+  Logic2.output = out::disable;       // Disable output on PD3 (we don't have to though)
+  Logic2.filter = filter::disable;    // No output filter enabled
+  Logic2.truth = 0x01;                // Set truth table
 
   // Initialize logic block 2
-  Logic.init(Logic.block2);
+  Logic2.init();
 
   // Set interrupt (supports RISING, FALLING and CHANGE)
-  Logic.attachInterrupt(Logic.block2, interruptFunction, RISING);
+  Logic2.attachInterrupt(interruptFunction, RISING);
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Three_input_AND/Three_input_AND.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_AND/Three_input_AND.ino
@@ -34,20 +34,20 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-  Logic.block0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0x80;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0x80;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Three_input_NAND/Three_input_NAND.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_NAND/Three_input_NAND.ino
@@ -34,20 +34,20 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-  Logic.block0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0x7F;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0x7F;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Three_input_OR/Three_input_OR.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_OR/Three_input_OR.ino
@@ -34,20 +34,20 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-  Logic.block0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0xFE;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0xFE;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Two_input_AND/Two_input_AND.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_AND/Two_input_AND.ino
@@ -36,19 +36,19 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0x08;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0x08;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Two_input_NAND/Two_input_NAND.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_NAND/Two_input_NAND.ino
@@ -36,19 +36,19 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0xF7;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0xF7;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/examples/Two_input_OR/Two_input_OR.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_OR/Two_input_OR.ino
@@ -36,19 +36,19 @@ void setup()
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
-  Logic.block0.enable = true;               // Enable logic block 0
-  Logic.block0.input0 = in::input_pullup;   // Set PA0 as input with pullup
-  Logic.block0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic.block0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic.block0.output = out::enable;        // Enable logic block 0 output pin (PA3)
-  Logic.block0.filter = filter::disable;    // No output filter enabled
-  Logic.block0.truth = 0xFE;                // Set truth table
+  Logic0.enable = true;               // Enable logic block 0
+  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.filter = filter::disable;    // No output filter enabled
+  Logic0.truth = 0xFE;                // Set truth table
 
   // Initialize logic block 0
-  Logic.init(Logic.block0);
+  Logic0.init();
 
   // Start the AVR logic hardware
-  Logic.start();
+  Logic::start();
 }
 
 void loop()

--- a/megaavr/libraries/Logic/src/Logic.h
+++ b/megaavr/libraries/Logic/src/Logic.h
@@ -67,119 +67,43 @@ namespace sequencer
   };
 };
 
-class CustomLogic
+class Logic
 {
-  private:
-    // Struct that holds all information a single logic block needs
-    typedef struct
-    {
-      const uint8_t block_number;
-      PORT_t* const PORT;
-      volatile uint8_t* const SEQCTRL;
-      volatile uint8_t* const LUTCTRLA;
-      volatile uint8_t* const LUTCTRLB;
-      volatile uint8_t* const LUTCTRLC;
-      volatile uint8_t* const TRUTH;
-      uint8_t input0;
-      uint8_t input1;
-      uint8_t input2;
-      uint8_t output;
-      uint8_t enable;
-      uint8_t truth;
-      uint8_t output_swap;
-      uint8_t filter;
-      uint8_t sequencer;
-    } block_t;
-
   public:
-    CustomLogic();
-    void start(bool state = true);
-    void end();
-    void init(block_t &block);
-    void attachInterrupt(block_t &block, voidFuncPtr callback, PinStatus mode);
-    void detachInterrupt(block_t &block);
-    
-    // Struct object for logic block 0 (IOs connected to PORTA)
-    block_t block0 = {
-      .block_number = 0,
-      .PORT = &PORTA, 
-      .SEQCTRL = &CCL_SEQCTRL0,
-      .LUTCTRLA = &CCL_LUT0CTRLA, 
-      .LUTCTRLB = &CCL_LUT0CTRLB, 
-      .LUTCTRLC = &CCL_LUT0CTRLC, 
-      .TRUTH = &CCL_TRUTH0, 
-      .input0 = in::masked, 
-      .input1 = in::masked, 
-      .input2 = in::masked, 
-      .output = false, 
-      .enable = false, 
-      .truth = 0x00,
-      .output_swap = out::no_swap,
-      .filter = filter::disable,
-      .sequencer = sequencer::disable,
-    };
-    
-    // Struct object for logic block 1 (IOs connected to PORTC)
-    block_t block1 = {
-      .block_number = 1,
-      .PORT = &PORTC, 
-      .SEQCTRL = &CCL_SEQCTRL0,
-      .LUTCTRLA = &CCL_LUT1CTRLA, 
-      .LUTCTRLB = &CCL_LUT1CTRLB, 
-      .LUTCTRLC = &CCL_LUT1CTRLC, 
-      .TRUTH = &CCL_TRUTH1, 
-      .input0 = in::masked, 
-      .input1 = in::masked, 
-      .input2 = in::masked, 
-      .output = out::disable, 
-      .enable = false, 
-      .truth = 0x00,
-      .output_swap = out::no_swap,
-      .filter = filter::disable,
-      .sequencer = sequencer::disable,
-    };
-    
-    // Struct object for logic block 2 (IOs connected to PORTD)
-    block_t block2 = {
-      .block_number = 2,
-      .PORT = &PORTD,
-      .SEQCTRL = &CCL_SEQCTRL1,
-      .LUTCTRLA = &CCL_LUT2CTRLA, 
-      .LUTCTRLB = &CCL_LUT2CTRLB, 
-      .LUTCTRLC = &CCL_LUT2CTRLC, 
-      .TRUTH = &CCL_TRUTH2, 
-      .input0 = in::masked,
-      .input1 = in::masked,
-      .input2 = in::masked,
-      .output = out::disable,
-      .enable = false,
-      .truth = 0x00,
-      .output_swap = out::no_swap,
-      .filter = filter::disable,
-      .sequencer = sequencer::disable,
-    };
-    
-    // Struct object for logic block 3 (IOs connected to PORTF)
-    block_t block3 = {
-      .block_number = 3,
-      .PORT = &PORTF,
-      .SEQCTRL = &CCL_SEQCTRL1,
-      .LUTCTRLA = &CCL_LUT3CTRLA, 
-      .LUTCTRLB = &CCL_LUT3CTRLB, 
-      .LUTCTRLC = &CCL_LUT3CTRLC, 
-      .TRUTH = &CCL_TRUTH3, 
-      .input0 = in::masked,
-      .input1 = in::masked,
-      .input2 = in::masked,
-      .output = out::disable,
-      .enable = false,
-      .truth = 0x00,
-      .output_swap = out::no_swap,
-      .filter = filter::disable,
-      .sequencer = sequencer::disable,
-    };
+    static void start(bool state = true);
+    static void end();
+
+    Logic(const uint8_t block_number,
+          PORT_t& port,
+          register8_t& seq_ctrl,
+          register8_t& lut_ctrla,
+          register8_t& lut_ctrlb,
+          register8_t& lut_ctrlc,
+          register8_t& truth);
+    void init();
+    void attachInterrupt(voidFuncPtr callback, PinStatus mode);
+    void detachInterrupt();
+
+    uint8_t input0;
+    uint8_t input1;
+    uint8_t input2;
+    uint8_t output;
+    uint8_t enable;
+    uint8_t truth;
+    uint8_t output_swap;
+    uint8_t filter;
+    uint8_t sequencer;
+
+private:
+    const uint8_t block_number;
+    PORT_t& PORT;
+    volatile register8_t& SEQCTRL;
+    volatile register8_t& LUTCTRLA;
+    volatile register8_t& LUTCTRLB;
+    volatile register8_t& LUTCTRLC;
+    volatile register8_t& TRUTH;
 };
 
-extern CustomLogic Logic;
+extern Logic Logic0, Logic1, Logic2, Logic3;
 
 #endif


### PR DESCRIPTION
This CL makes 4 CCL block instances in Logic object separated in Logic0 through Logic3 objects. Thus compiler/linker can optimize out unused block object from a sketch and reduce RAM consumption.