### PR TITLE
Fix period of PWM timers

### DIFF
--- a/megaavr/cores/coreX-corefiles/timers.h
+++ b/megaavr/cores/coreX-corefiles/timers.h
@@ -5,7 +5,7 @@
 #define TIME_TRACKING_TIMER_DIVIDER   1     // Timer F_CPU Clock divider (can be 1 or 2)
 #define TIME_TRACKING_TIMER_COUNT     (F_CPU/(1000*TIME_TRACKING_TIMER_DIVIDER)) // Should correspond to exactly 1 ms, i.e. millis()
 
-#define PWM_TIMER_PERIOD   0xFF  // For frequency
+#define PWM_TIMER_PERIOD   0xFE  // For frequency
 #define PWM_TIMER_COMPARE  0x80  // For duty cycle
 
 #endif

--- a/megaavr/cores/coreX-corefiles/wiring_analog.c
+++ b/megaavr/cores/coreX-corefiles/wiring_analog.c
@@ -130,11 +130,11 @@ void analogWrite(uint8_t pin, int val)
 	// call for the analog output pins.
 	pinMode(pin, OUTPUT);
 
-	if(val < 1){	/* if zero or negative drive digital low */
+	if(val <= 0){   /* if zero or negative drive digital low */
 
 		digitalWrite(pin, LOW);
 
-	} else if(val > 255){	/* if max or greater drive digital high */
+	} else if(val >= 255){  /* if max or greater drive digital high */
 
 		digitalWrite(pin, HIGH);
 


### PR DESCRIPTION
so that the value 0 is to LOW, the value 255 is HIGH, and any value inbetween
is a corresponding PWM pulse.
The previous behaviour was that the range was 0 to 256, which is not in
accordance to the Arduino standard.