### PR TITLE
Change wire to a Stream instead of HardwareI2C

### DIFF
--- a/megaavr/libraries/Wire/src/Wire.h
+++ b/megaavr/libraries/Wire/src/Wire.h
@@ -28,7 +28,7 @@
 
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
-class TwoWire : public HardwareI2C
+class TwoWire : public Stream
 {
   private:
     static uint8_t rxBuffer[];


### PR DESCRIPTION
See https://github.com/SpenceKonde/megaTinyCore/pull/130

Losing the stupid HardwareI2C typing prevents it from pulling in a flash-wasting vtable., and as far as I can no libraries in circulation  that depend on it being a HardwareI2C.