### PR TITLE
Pull in changes from DxCore

### DIFF
--- a/megaavr/libraries/Logic/README.md
+++ b/megaavr/libraries/Logic/README.md
@@ -1,17 +1,19 @@
 # Logic
-A library for interfacing with the CCL (Configurable Custom Logic) peripherals of the megaAVR-0 MCUs.  
-Developed by MCUdude for use with [MegaCoreX](https://github.com/MCUdude/MegaCoreX).  
-The megaAVR-0 has four independent internal logic blocks that can be individually customized.  
-More useful information about CCL can be found in the [Microchip Application Note TB3218](http://ww1.microchip.com/downloads/en/AppNotes/TB3218-Getting-Started-with-CCL-90003218A.pdf) and in the [megaAVR-0 family data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/megaAVR0-series-Family-Data-Sheet-DS40002015B.pdf).
+A library for interfacing with the CCL (Configurable Custom Logic) peripherals of the megaAVR-0 MCUs.
+Developed by MCUdude for use with [MegaCoreX](https://github.com/MCUdude/MegaCoreX), adapted to megaAVR ATtiny parts by [Tadashi G. Takaoka](https://github.com/tgtakaoka), and to DA-series by [Spence Konde](https://github.com/SpenceKonde)
+Correction of several issues on the megaAVR ATtiny parts and adaptation of examples by [Spence Konde](https://github.com/SpenceKonde).
+All of the megaTiny parts have 2 blocks of CCL available. The examples included assume the use of megaTinyCore in their defines to detect the applicable part.
+More useful information about CCL can be found in the [Microchip Application Note TB3218](http://ww1.microchip.com/downloads/en/AppNotes/TB3218-Getting-Started-with-CCL-90003218A.pdf) and in the [megaAVR-0 family data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/megaAVR0-series-Family-Data-Sheet-DS40002015B.pdf), or the datasheet for the ATtiny part in question.
+
 
 
 ## Logic
-Class for interfacing with the built-in logic block. use the predefined objects `Logic0`, `Logic1`, `Logic2` and `Logic3`.
+Class for interfacing with the built-in logic block. use the predefined objects `Logic0`, `Logic1`, `Logic2` and `Logic3`. `Logic2` and `Logic3` are only available on the ATmega parts.
 Each object contains register pointers for interfacing with the right registers. Some of these variables are available to the user.
 
 
 ### enable
-Variable for enabling or disabling a logic block. 
+Variable for enabling or disabling a logic block.
 Accepted values:
 ```c++
 true;  // Enable the current logic block
@@ -28,30 +30,86 @@ Logic0.enable = true; // Enable logic block 0
 
 
 ### input0..input2
-Variable for setting what mode input 0..2 on a logic block should have.  
-Accepted values:
+Variable for setting what mode input 0..2 on a logic block should have.
+
+Notes for all parts:
+* The datasheets give different names for the event channels for ATtiny and ATmega parts, both are supported by library: event 0 and event a are the same, as are event 1 and event b. These can be generated using the event system, see the relevant datasheet and examples for more information.
+* Timer WO channels correspond to the specified timer's PWM Output channels. They are true when the specified timer's value is higher than the compare register for that output channel.
+* Type-B timers can only generate an output under circumstances where they could drive an output pin if CCMPEN in TCBn.CTRLA is set.
+
+Accepted values for DA-series and megaAVR 0-series parts:
 ``` c++
-in::masked;       // Pin not in use
-in::unused;       // Pin not in use
-in::disable;      // Pin not in use
-in::feedback;     // Connect output of the logic block to this input
-in::link;         // Connect output of logic block n+1 to this input
-in::event_a;      // Connect input to event A
-in::event_b;      // Connect input to event B
-in::input;        // Connect input to GPIO
-in::ac;           // Connect input to the output of the internal analog comparator
-in::input_pullup; // Connect input to GPIO and enable the internal pullup resistor
-in::uart;         // Connect input to UART TX. Input 0 connects to UART0 TX, input 1 to UART1 TX, and input 2 to UART2 TX
-in::spi;          // Connect input to SPI. Input 0 and 1 connects to MOSI, and input 2 connects to SCK
-in::tca0;         // Connect input to TCA0. Input 0 connects to WO0, input 1 to WO1 and input2 to WO2
-in::tcb;          // Connect input to TCB. Input 0 connects to TCB0 W0, input 1 to TCB1 WO, and input 2 to TCB2 WO
+in::masked;           // Pin not in use
+in::unused;           // Pin not in use
+in::disable;          // Pin not in use
+in::feedback;         // Connect output of the logic block to this input
+in::link;             // Connect output of logic block n+1 to this input
+in::event_0;          // Connect input to event a
+in::event_a;          // Connect input to event a
+in::event_1;          // Connect input to event b
+in::event_b;          // Connect input to event b
+in::pin;              // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, do not change pinMode
+in::input_pullup;     // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup on
+in::input;            // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup off
+in::input_no_pullup;  // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup off
+in::ac;               // Connect input to the output of the internal analog comparator (input 0,1,2 from AC0,1,2)
+in::zcd;              // Connect input to the output of the zero crossing detector (input 0,1,2 from ZCD0,1,2) - DA-series only
+in::uart;             // Connect input to UART TX. Input 0 connects to UART0 TX, input 1 to UART1 TX, and input 2 to UART2 TX
+in::spi;              // Connect input to SPI. Input 0 and 1 connects to MOSI, and input 2 connects to SCK
+in::tca0;             // Connect input to TCA0. Input 0 connects to WO0, input 1 to WO1 and input2 to WO2
+in::tca1;             // Connect input to TCA1. Input 0 connects to WO0, input 1 to WO1 and input2 to WO2 - DA-series only
+in::tcb;              // Connect input to TCB. Input 0 connects to TCB0 W0, input 1 to TCB1 WO, and input 2 to TCB2 WO.
+in::tcd;              // Connect input to TCD0. Input 0 connects to WOA, input 1 to WOB and input2 to WOC - DA-series only
 ```
+
+Notes specific to ATmega parts
+* The 48-pin and 64-pin DA-series parts have 6 LUTs. No pins for CCL5 are available in the 48-pin package.
+* On 28-pin versions of the ATmega 4808, 3208, 1608, and 808, IN1 and IN2 inputs for logic3 are not available. If all input pins for all logic blocks are needed, the event system workaround shown for the ATtiny parts in the examples can be used, though note that register names and values are different. Same principle applies to the DA-series devices with fewer pins.
+* According to the datasheet for SPI as input source, inputs 0 and 1 connect to MOSI. Thus, on these parts, there is no input to the logic blocks for MISO. Note also that the order is different from the ATtiny parts.
+* If input on the highest-number Logic block is set to link, it will use the output of Logic0 (unless it's an early production DA-series - see the errata)
+* If you need to link input to logic block other than the n+1 block, you can use the event system for that.
+
+Accepted values for tinyAVR 0/1-series parts:
+
+``` c++
+in::masked;           // Pin not in use
+in::unused;           // Pin not in use
+in::disable;          // Pin not in use
+in::feedback;         // Connect output of the logic block to this input
+in::link;             // Connect output of the other logic block to this input
+in::event_0;          // Connect input to event 0
+in::event_a;          // Connect input to event 0
+in::event_1;          // Connect input to event 1
+in::event_b;          // Connect input to event 1
+in::pin;              // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, do not change pinMode
+in::input_pullup;     // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup on
+in::input;            // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup off
+in::input_no_pullup;  // Connect input to CCL IN0, IN1, IN2 for input 0, 1, 2, set input, pullup off
+in::ac0;              // Connect input to AC0 OUT
+in::tcb0;             // Connect input to TCB0 WO
+in::tca;              // Connect input to TCA0 WO0~2 for input 0~2
+in::tca0;             // Connect input to TCA0 WO0~2 for input 0~2
+in::tcd;              // Connect input to TCD WOAn, WOB, WOA for input 0, 1, 2
+in::usart;            // Connect input to U(S)ART0 XCK and TXD for input 0, 1
+in::spi;              // Connect input to SPI0 SCK, MOSI, MISO for input 0, 1, 2
+in::ac1;              // Connect input to AC1 OUT (input 0, 1 only)
+in::tcb1;             // Connect input to TCB1 WO (input 0, 1 only)
+in::ac2;              // Connect input to AC2 OUT (input 0, 1 only)
+```
+
+Notes specific to ATtiny:
+* It is not clear what TCD0 WOAn is. I suspect it is true when TCD0 count is greater than TCD0.COMPSET0 and TCD0.CMPCLR0, ie, when WOA turns on and off, which can be individually controlled; the timer continues counting until reaching TCD0.CMPCLR1 when WOB turns off (TCD0 is a very strange timer).
+* Not all inputs are available on all parts - only input sources corresponding to peripherals on that device are available. Not all options are avalable for input 2, as noted above.
+* On CCL1 (logic1), IN0 I/O input is available only on the 20 and-24 pin parts, and IN1 and IN2 only on 24-pin parts. The event inputs can be used with pin events to take input from a diferent pins for up to two inputs. This is demonstrated in the five input example.
+* CCL0's IN0 pin is on PA0, which is nominally the UPDI pin. It can only be used as input when that pin is set as GPIO. This limits the usefulness of CCL0 on the ATtiny parts; configuring UPDI as GPIO prevents further programming via UPDI except via HV programming. Configuring this option is only supported on megaTinyCore with Optiboot bootloader (from 1.1.6 on), and prevents further modification of the fuses or bootloader without HV programming, however, as noted above, input0 can be used via the event inputs to take input from another pin. This is demonstrated in the three input examples.
+
+
 
 ##### Usage
 ``` c++
-Logic0.input0 = in::link;  // Connect output from block 1 to input 0 of block 0
-Logic0.input1 = in::input; // Connect the input 1 from block 0 to its GPIO
-Logic0.input2 = in::input_pullup; // Connect the input 2 from block 0 to its GPIO and enable pullup
+Logic0.input0 = in::link;         // Connect output from block 1 to input 0 of block 0
+Logic0.input1 = in::input;        // Connect the input 1 from block 0 to its GPIO
+Logic0.input2 = in::input_pullup; // Connect the input 2 from block 0 to its GPIO, with pullup on
 ```
 
 ##### Default state
@@ -59,7 +117,7 @@ Logic0.input2 = in::input_pullup; // Connect the input 2 from block 0 to its GPI
 
 
 ### output
-Variable for changing the logic block output pin behavior. Note that the output of the logic block still can be used internally if the output pin is disabled.  
+Variable for changing the logic block output pin behavior. Note that the output of the logic block still can be used internally if the output pin is disabled.
 Accepted values:
 ```c++
 out::disable; // Disable the output GPIO pin. Useful when triggering an interrupt instead.
@@ -76,7 +134,7 @@ Logic0.output = out::disable; // Disable the output GPIO pin.
 
 
 ### output_swap
-Variable for pin swapping the physical output pin to its alternative position. See the pinout diagrams in the main MegaCoreX README for detailed info.  
+Variable for pin swapping the physical output pin to its alternative position. See the pinout diagrams in the [Core this is part of](../../../README.md) for more info.
 Accepted values:
 ```c++
 out::no_swap;  // Use default pin position, pin 2 on the port
@@ -93,12 +151,12 @@ Logic0.output_swap = out::no_swap; // No pin swap for output of block0
 
 
 ### filter
-Variable to connecting a filter or synchronizer to the logic block output. Useful when multiple logic blocks are connected internally to prevent logic race.  
+Variable to connect a filter or synchronizer to the logic block output. Useful when multiple logic blocks are connected internally to prevent race conditions and glitches that could arise due to the asynchronous nature of CCL clocking. Either filter or synchronizer is required for edge detector, below.
 Accepted values:
 ```c++
 filter::disable;      // No filter used
-filter::synchronizer; // Connect synchronizer to output
-filter::filter;       // Connect filter to output
+filter::synchronizer; // Connect synchronizer to output; delays output by 2 clock cycles.
+filter::filter;       // Connect filter to output; delays output by 4 clock cycles, only passes output that is stable for >2 clock cycles.
 ```
 
 ##### Usage
@@ -110,14 +168,44 @@ Logic0.filter = filter::filter; // Enable filter on output of block 0
 `LogicN.filter` defaults to `filter::disable` if not specified in the user program.
 
 
+### clocksource
+Variable set the clock source for the LUT. The inputs are checked and output updated on the rising edge of this clock. Except on the Dx-series parts, only clk_per (peripheral clock, ie, the system clock) and in2 are available. If you don't know what this means, you want clk_per. If sequential logic is used, this is also used to clock that.
+Accepted values:
+```c++
+clocksource::clk_per;      // Clock from the peripheral clock (ie, system clock)
+clocksource::in2;          // Clock from the selected input2; it is treated as a 0 in the truth table.
+clocksource::oschf;        // Clock from the **unprescaled** internal HF oscillator. Same as clk_per if system clock not prescaled.
+clocksource::osc32k;       // Clock from the internal 32.768 kHz oscillator
+clocksource::osc1l;        // Clock from the internal 32.768 kHz oscillator prescaled by 32
+```
+
+
+##### Usage
+```c++
+Logic2.filter = filter::filter; // Set Block2 to use unprescaled high frequency internal oscillator.
+```
+
+##### Default state
+`LogicN.filter` defaults to `filter::disable` if not specified in the user program.
+
+
+
+### edgedetect
+Variable for controlling use of the edge detector. The edge detector can be used to generate a pulse when detecting a rising edge on its input. To detect a falling edge, the TRUTH table should be programmed to provide inverted output. In order to avoid unpredictable behavior, a valid filter option must be enabled. Note that this is likely only of use when the output is being used for sequential logic or as the input to another logic block; it looks particularly useful on the odd LUT input to a J-K flip-flop sequential logic unit.
+
+```c++
+edgedetect::disable;      // No edge detection used
+edgedetect::enable;       // Edge detection used
+```
+
 ### sequencer
-Variable for connecting a sequencer to the logic block output.  
+Variable for connecting a sequencer to the logic block output. There is 1 sequencer per 2 CCLs; this option is ignored for the odd-numbered logic blocks.
 Accepted values:
 ```c++
 sequencer::disable;      // No sequencer connected
 sequencer::d_flip_flop;  // D flip flop sequencer connected
 sequencer::jk_flip_flop; // JK flip flop sequencer connected
-sequencer::d_latch;      // D latch sequencer connected
+sequencer::d_latch;      // D latch sequencer connected - note that on most tinyAVR and megaAVR parts, this doesn't work. See the Errata. It should work on Dx-series.
 sequencer::rs_latch;     // RS latch sequencer connected
 ```
 
@@ -131,7 +219,7 @@ Logic0.sequencer = sequencer::disable; // Disable sequencer
 
 
 ### truth
-Variable to hold the 8-bit truth table value.  
+Variable to hold the 8-bit truth table value.
 Accepted values between 0x00 and 0xFF.
 
 ##### Usage
@@ -176,9 +264,9 @@ Logic::stop(); // Stop CCL
 
 
 ## attachInterrupt()
-Method for enabling interrupts for a specific block.  
+Method for enabling interrupts for a specific block.
 Valid arguments for the third parameters are `RISING`, `FALLING` and `CHANGE`.
-This method ins't available on tinyAVR series.
+This method ins't available on tinyAVR series, as these parts cannot generate an interrupt from the CCL blocks.
 
 ##### Usage
 ```c++

--- a/megaavr/libraries/Logic/examples/Five_input_NOR/Five_input_NOR.ino
+++ b/megaavr/libraries/Logic/examples/Five_input_NOR/Five_input_NOR.ino
@@ -20,27 +20,66 @@
 void setup()
 {
   // Initialize logic block 1
-  // Logic block 1 has three inputs, PC0, PC1 and PC2.
-  // It's output, PC3 is disabled because we connect the output signal to block 0 internally
+  // Logic block 1 has three inputs, PC0, PC1 and PC2 on ATmega parts
+  // Logic block 1 inputs are PC3, PC4, and PC5 on ATtiny parts, but
+  // only 24-pin parts have all three. 20-pin parts have PC3 only.
+  // Because PA0 is not available on ATtiny under most situations
+  // on megaTinyCore, we use input0 of logic block 0 as link from
+  // other logic block. On the 20-pin parts, we also use the event system to
+  // get the other two inputs from other pins.
+
+
+  // Here, input2 is taken from the other
+  // This example shows how this can be worked around for 20-pin parts
+  // It's output is disabled because we connect the output signal to block 0 internally
   Logic1.enable = true;               // Enable logic block 1
-  Logic1.input0 = in::input_pullup;   // Set PC0 as input with pullup
-  Logic1.input1 = in::input_pullup;   // Set PC1 as input with pullup
-  Logic1.input2 = in::input_pullup;   // Set PC2 as input with pullup
-  Logic1.output = out::disable;       // No output on PC3
+
+  #if defined(MEGATINYCORE) && defined(__AVR_ATtinyxy6__)
+  // only use this workaround if it's a 20-pin part.
+  // Here, PA3 is used as input 1 and PB0 is used as input 2
+
+  PORTA.DIRCLR=(1<<3);                // set PA3 as input
+  PORTA.PIN3CTRL|=PORT_PULLUPEN_bm;   // enable pullup
+  EVSYS.ASYNC0=0x0D;                  // PA3 per table 14-2 in datasheet
+  EVSYS.ASYNCUSER3= 0x03;             // Use Async0 as LUT1 event 0 per Table 14-4 in datasheet
+  Logic0.input1 = in::event_0;        // Use LUT event 0 as input 1, which will take input from PA3
+
+  PORTB.DIRCLR=(1<<0);                // set PB0 as input
+  PORTB.PIN0CTRL|=PORT_PULLUPEN_bm;   // enable pullup
+  EVSYS.ASYNC1=0x0A;                  // PB0 per table 14-2 in datasheet
+  EVSYS.ASYNCUSER5= 0x04;             // Use Async1 as LUT1 event 1 per Table 14-4 in datasheet
+  Logic1.input2 = in::event_1;        // Use LUT event 1 as input 2, which will take input from PB0
+
+  #elif defined(MEGATINYCORE) && !defined(__AVR_ATtinyxy7__)
+  // If it's neither 20-pin nor 24-pin part, cannot be used.
+
+  #error "The 8-pin and 14-pin parts do not support this"
+
+  #else
+  // Otherwise it is an ATmega or ATtiny with 24 pins, and no workaround needed.
+
+  Logic1.input1 = in::input_pullup;   // Set PC1 or PC4 as input with pullup
+  Logic1.input2 = in::input_pullup;   // Set PC2 or PC5 input with pullup
+
+  #endif
+  //End of workaround code
+
+  Logic1.input0 = in::input_pullup;   // Set PC0 or PC3 as input with pullup
+  Logic1.output = out::disable;       // Enable output pin
   Logic1.filter = filter::disable;    // No output filter enabled
-  Logic1.truth = 0xFE;                // Set truth table
-  
+  Logic1.truth = 0x01;                // Set truth table
+
   // Initialize logic block 0
-  // Logic block 0 has three inputs, PA0, PA1 and PA2. 
-  // input2 is internally connected to the output of block1 (which means PA2 is freed up)
-  // Block 0 output on PA3
+  // Logic block 0 has three inputs, PA0, PA1 and PA2.
+  // Block 0 output on PA3 on ATmega, PA5 on ATtiny.
+
   Logic0.enable = true;               // Enable logic block 0
-  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  Logic0.input0 = in::link;           // Route output from block 1 to this input internally
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-  Logic0.input2 = in::link;           // Route output from block 1 to this input internally
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
-  Logic0.truth = 0x01;                // Set truth table
+  Logic0.truth = 0xFE;                // Set truth table
 
   // Initialize logic block 0 and 1
   Logic0.init();

--- a/megaavr/libraries/Logic/examples/Interrupt/Interrupt.ino
+++ b/megaavr/libraries/Logic/examples/Interrupt/Interrupt.ino
@@ -33,7 +33,10 @@ void setup()
 {
   // Modify the serial port to match your hardware
   Serial.begin(9600);
-  
+
+  // The interrupt is only available on ATmega parts.
+  // This will error on ATtiny parts.
+
   // Initialize logic block 2
   // Logic block 2 has three inputs, PA0, PA1 and PA2.
   // It has one output, but this is disabled because we're using an interrupt instead.
@@ -41,7 +44,7 @@ void setup()
   Logic2.input0 = in::input_pullup;   // Set PD0 as input with pullup
   Logic2.input1 = in::input_pullup;   // Set PD1 as input with pullup
   Logic2.input2 = in::input_pullup;   // Set PD2 as input with pullup
-  Logic2.output = out::disable;       // Disable output on PD3 (we don't have to though)
+  Logic2.output = out::disable;       // Disable output on PA0 (we don't have to though)
   Logic2.filter = filter::disable;    // No output filter enabled
   Logic2.truth = 0x01;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Three_input_AND/Three_input_AND.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_AND/Three_input_AND.ino
@@ -22,8 +22,8 @@
 | binary number into hex, we                | 0 | 1 | 1 | 0 |           |
 | get 0x80.                                 | 1 | 0 | 0 | 0 |           |
 |                                           | 1 | 0 | 1 | 0 |           |
-| In this example the output pin,           | 1 | 1 | 0 | 0 |           |
-| PA3 will go high if all three             | 1 | 1 | 1 | 1 |           |
+| In this example the output pin            | 1 | 1 | 0 | 0 |           |
+| will go high if all three                 | 1 | 1 | 1 | 1 |           |
 | inputs are high.                                                      |
 |***********************************************************************/
 
@@ -33,13 +33,29 @@ void setup()
 {
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
-  // It has one output, PA3, but can be swapped to PA6 if needed
+  // Because PA0 is shared with the UPDI pin and is not usually an option
+  // we use PA3 via the event system in this example on ATtiny parts
+  // It has one output, PA3 on ATmega, PA5 on ATtiny.
+  // Or alternate output on PA6 on ATmega, PB6 on 20 and 24-pin ATtiny.
+
   Logic0.enable = true;               // Enable logic block 0
+
+  #ifdef MEGATINYCORE
+  //For ATtiny parts, we have to work around PA0 being UPDI
+  PORTA.DIRCLR=(1<<3);                // set PA3 as input
+  PORTA.PIN3CTRL|=PORT_PULLUPEN_bm;   // enable pullup
+  EVSYS.ASYNC0=0x0D;                  // PA3 per table 14-2 in datasheet
+  EVSYS.ASYNCUSER2= 0x03;             // Use Async0 as LUT0 event 0 per Table 14-4 in datasheet
+  Logic0.input0 = in::event_0;        // Use LUT event 0 as input 0
+  #else
+  //For ATmega parts, PA0 is a normal input pin, so we use it.
   Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  #endif
+
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
   Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to alternate location, if available.
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0x80;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Three_input_NAND/Three_input_NAND.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_NAND/Three_input_NAND.ino
@@ -23,7 +23,7 @@
 | get 0x7F.                                 | 1 | 0 | 0 | 1 |           |
 |                                           | 1 | 0 | 1 | 1 |           |
 | In this example the output pin            | 1 | 1 | 0 | 1 |           |
-| PA3 will go low if all three              | 1 | 1 | 1 | 0 |           |
+| will go low if all three                  | 1 | 1 | 1 | 0 |           |
 | inputs are high.                                                      |
 |***********************************************************************/
 
@@ -33,13 +33,29 @@ void setup()
 {
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
-  // It has one output, PA3, but can be swapped to PA6 if needed
+  // Because PA0 is shared with the UPDI pin and is not usually an option
+  // we use PA3 via the event system in this example on ATtiny parts
+  // It has one output, PA3 on ATmega, PA5 on ATtiny.
+  // Or alternate output on PA6 on ATmega, PB6 on 20 and 24-pin ATtiny.
+
   Logic0.enable = true;               // Enable logic block 0
+
+  #ifdef MEGATINYCORE
+  //For ATtiny parts, we have to work around PA0 being UPDI
+  PORTA.DIRCLR=(1<<3);                // set PA3 as input
+  PORTA.PIN3CTRL|=PORT_PULLUPEN_bm;   // enable pullup
+  EVSYS.ASYNC0=0x0D;                  // PA3 per table 14-2 in datasheet
+  EVSYS.ASYNCUSER2= 0x03;             // Use Async0 as LUT0 event 0 per Table 14-4 in datasheet
+  Logic0.input0 = in::event_0;        // Use LUT event 0 as input 0
+  #else
+  //For ATmega parts, PA0 is a normal input pin, so we use it.
   Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  #endif
+
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
   Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to alternate location, if available.
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0x7F;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Three_input_OR/Three_input_OR.ino
+++ b/megaavr/libraries/Logic/examples/Three_input_OR/Three_input_OR.ino
@@ -22,8 +22,8 @@
 | binary number into hex, we                | 0 | 1 | 1 | 1 |           |
 | get 0xFE.                                 | 1 | 0 | 0 | 1 |           |
 |                                           | 1 | 0 | 1 | 1 |           |
-| In this example the output pin,           | 1 | 1 | 0 | 1 |           |
-| PA3 will go high if one or more           | 1 | 1 | 1 | 1 |           |
+| In this example the output pin            | 1 | 1 | 0 | 1 |           |
+| will go high if one or more               | 1 | 1 | 1 | 1 |           |
 | inputs are high.                                                      |
 |***********************************************************************/
 
@@ -33,13 +33,29 @@ void setup()
 {
   // Initialize logic block 0
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
-  // It has one output, PA3, but can be swapped to PA6 if needed
+  // Because PA0 is shared with the UPDI pin and is not usually an option
+  // we use PA3 via the event system in this example on ATtiny parts
+  // It has one output, PA3 on ATmega, PA5 on ATtiny.
+  // Or alternate output on PA6 on ATmega, PB6 on 20 and 24-pin ATtiny.
+
   Logic0.enable = true;               // Enable logic block 0
+
+  #ifdef MEGATINYCORE
+  //For ATtiny parts, we have to work around PA0 being UPDI
+  PORTA.DIRCLR=(1<<3);                // set PA3 as input
+  PORTA.PIN3CTRL|=PORT_PULLUPEN_bm;   // enable pullup
+  EVSYS.ASYNC0=0x0D;                  // PA3 per table 14-2 in datasheet
+  EVSYS.ASYNCUSER2= 0x03;             // Use Async0 as LUT0 event 0 per Table 14-4 in datasheet
+  Logic0.input0 = in::event_0;        // Use LUT event 0 as input 0
+  #else
+  //For ATmega parts, PA0 is a normal input pin, so we use it.
   Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
+  #endif
+
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
   Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to alternate location, if available.
+  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0xFE;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Two_input_AND/Two_input_AND.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_AND/Two_input_AND.ino
@@ -11,22 +11,22 @@
 | megaAVR to create a 2-input AND gate using logic block 0 on PORT A.   |
 | The example is pretty straight forward, but the truth table value may |
 | be a little difficult to understand at first glance.                  |
-| We will only use PA0 and PA1 as inputs. When the last input is        |
+| We will only use PA1 and PA2 as inputs. when the first input is       |
 | disabled it will always be read as 0.                                 |
 | Here's how 0x08 turns out to be the correct value to create a 2-input |
 | NAND gate:                                                            |
 |                                     2-input AND truth table:          |
-| If we look at the truth table       |PA2|PA1|PA0| Y |                 |
+| If we look at the truth table       |PA0|PA1|PA2| Y |                 |
 | to the right, we can see that       |---|---|---|---|                 |
 | all binary values for Y can         | 0 | 0 | 0 | 0 |                 |
 | be represented as 00001000.         | 0 | 0 | 1 | 0 |                 |
 | If we convert this 8-bit            | 0 | 1 | 0 | 0 |                 |
 | binary number into hex, we          | 0 | 1 | 1 | 1 |                 |
-| get 0x08.                           | 1 | 0 | 0 | 0 | PA2 is always 0 |
-|                                     | 1 | 0 | 1 | 0 | PA2 is always 0 |
-| In this example the output pin,     | 1 | 1 | 0 | 0 | PA2 is always 0 |
-| PA3 will only go high if the        | 1 | 1 | 1 | 0 | PA2 is always 0 |
-| two input pins are high.                                              |
+| get 0x08.                           | 1 | 0 | 0 | 0 | PA0 is always 0 |
+|                                     | 1 | 0 | 1 | 0 | PA0 is always 0 |
+| In this example the output pin      | 1 | 1 | 0 | 0 | PA0 is always 0 |
+| will only go high if the two        | 1 | 1 | 1 | 0 | PA0 is always 0 |
+| input pins are high.                                                  |
 |***********************************************************************/
 
 #include <Logic.h>
@@ -34,13 +34,13 @@
 void setup()
 {
   // Initialize logic block 0
-  // Logic block 0 has three inputs, PA0, PA1 and PA2.
-  // It has one output, PA3, but can be swapped to PA6 if needed
+  // It has one output, PA3 on ATmega, PA5 on ATtiny.
+  // Or alternate output on PA6 on ATmega, PB6 on 20 and 24-pin ATtiny.
   Logic0.enable = true;               // Enable logic block 0
-  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to alternate location, if available.
+  Logic0.output = out::enable;        // Enable logic block 0 output pin  (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0x08;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Two_input_NAND/Two_input_NAND.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_NAND/Two_input_NAND.ino
@@ -11,21 +11,21 @@
 | megaAVR to create a 2-input NAND gate using logic block 0 on PORT A.  |
 | The example is pretty straight forward, but the truth table value may |
 | be a little difficult to understand at first glance.                  |
-| We will only use PA0 and PA1 as inputs. when the last input is        |
-| disabled it will always be read as 0.                                 |
+| We will only use PA1 and PA2 as inputs. when the first input is       |
+| disabled it will always be read as 0.                                 ||
 | Here's how 0xF7 turns out to be the correct value to create a 2-input |
 | NAND gate:                                                            |
 |                                     2-input NAND truth table:         |
-| If we look at the truth table       |PA2|PA1|PA0| Y |                 |
+| If we look at the truth table       |PA0|PA1|PA2| Y |                 |
 | to the right, we can see that       |---|---|---|---|                 |
 | all binary values for Y can         | 0 | 0 | 0 | 1 |                 |
 | be represented as 11110111.         | 0 | 0 | 1 | 1 |                 |
 | If we convert this 8-bit            | 0 | 1 | 0 | 1 |                 |
 | binary number into hex, we          | 0 | 1 | 1 | 0 |                 |
-| get 0xF7.                           | 1 | 0 | 0 | 1 | PA2 is always 0 |
-|                                     | 1 | 0 | 1 | 1 | PA2 is always 0 |
-| In this example the output pin,     | 1 | 1 | 0 | 1 | PA2 is always 0 |
-| PA3 will only go low if the         | 1 | 1 | 1 | 1 | PA2 is always 0 |
+| get 0xF7.                           | 1 | 0 | 0 | 1 | PA0 is always 0 |
+|                                     | 1 | 0 | 1 | 1 | PA0 is always 0 |
+| In this example the output pin,     | 1 | 1 | 0 | 1 | PA0 is always 0 |
+| PA3 will only go low if the         | 1 | 1 | 1 | 1 | PA0 is always 0 |
 | two input pins are high.                                              |
 |***********************************************************************/
 
@@ -37,10 +37,10 @@ void setup()
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
   Logic0.enable = true;               // Enable logic block 0
-  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
-  Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to alternate location, if available.
+  Logic0.output = out::enable;        // Enable logic block 0 output pin  (PA3 (ATmega) or PA5 (ATtiny))
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0xF7;                // Set truth table
 

--- a/megaavr/libraries/Logic/examples/Two_input_OR/Two_input_OR.ino
+++ b/megaavr/libraries/Logic/examples/Two_input_OR/Two_input_OR.ino
@@ -11,21 +11,21 @@
 | megaAVR to create a 2-input OR gate using logic block 0 on PORT A.    |
 | The example is pretty straight forward, but the truth table value may |
 | be a little difficult to understand at first glance.                  |
-| We will only use PA0 and PA1 as inputs. When the last input is        |
+| We will only use PA1 and PA2 as inputs. when the first input is       |
 | disabled it will always be read as 0.                                 |
 | Here's how 0xFE turns out to be the correct value to create a 2-input |
 | OR gate:                                                              |
 |                                     2-input OR truth table:           |
-| If we look at the truth table       |PA2|PA1|PA0| Y |                 |
+| If we look at the truth table       |PA0|PA1|PA2| Y |                 |
 | to the right, we can see that       |---|---|---|---|                 |
 | all binary values for Y can         | 0 | 0 | 0 | 0 |                 |
 | be represented as 11111110.         | 0 | 0 | 1 | 1 |                 |
 | If we convert this 8-bit            | 0 | 1 | 0 | 1 |                 |
 | binary number into hex, we          | 0 | 1 | 1 | 1 |                 |
-| get 0xFE.                           | 1 | 0 | 0 | 1 | PA2 is always 0 |
-|                                     | 1 | 0 | 1 | 1 | PA2 is always 0 |
-| In this example the output pin,     | 1 | 1 | 0 | 1 | PA2 is always 0 |
-| PA3 will go high if one of          | 1 | 1 | 1 | 1 | PA2 is always 0 |
+| get 0xFE.                           | 1 | 0 | 0 | 1 | PA0 is always 0 |
+|                                     | 1 | 0 | 1 | 1 | PA0 is always 0 |
+| In this example the output pin,     | 1 | 1 | 0 | 1 | PA0 is always 0 |
+| PA3 will go high if one of          | 1 | 1 | 1 | 1 | PA0 is always 0 |
 | the input pins are high.                                              |
 |***********************************************************************/
 
@@ -37,9 +37,9 @@ void setup()
   // Logic block 0 has three inputs, PA0, PA1 and PA2.
   // It has one output, PA3, but can be swapped to PA6 if needed
   Logic0.enable = true;               // Enable logic block 0
-  Logic0.input0 = in::input_pullup;   // Set PA0 as input with pullup
   Logic0.input1 = in::input_pullup;   // Set PA1 as input with pullup
-//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to PA6 instead of PA3
+  Logic0.input2 = in::input_pullup;   // Set PA2 as input with pullup
+//Logic0.output_swap = out::pin_swap; // Uncomment this line to route the output to to alternate location, if available.
   Logic0.output = out::enable;        // Enable logic block 0 output pin (PA3)
   Logic0.filter = filter::disable;    // No output filter enabled
   Logic0.truth = 0xFE;                // Set truth table

--- a/megaavr/libraries/Logic/keywords.txt
+++ b/megaavr/libraries/Logic/keywords.txt
@@ -1,5 +1,5 @@
 #######################################
-# Syntax Coloring Map For Wire
+# Syntax Coloring Map For Logic
 #######################################
 
 #######################################
@@ -35,3 +35,4 @@ in	LITERAL1
 out	LITERAL1
 filter	LITERAL1
 sequencer	LITERAL1
+clocksource LITERAL1

--- a/megaavr/libraries/Logic/library.properties
+++ b/megaavr/libraries/Logic/library.properties
@@ -1,8 +1,8 @@
 name=Logic
-version=1.0.0
+version=1.0.2
 author=MCUdude
 maintainer=MCUdude
-sentence=A library for interfacing with the customizable logic in megaAVR chips
+sentence=A library for interfacing with the customizable logic in megaAVR 0-series, tinyAVR 0/1-series, and Dx-series chips
 paragraph=
 category=Signal Input/Output
 url=https://github.com/MCUdude/MegaCoreX

--- a/megaavr/libraries/Logic/src/Logic.h
+++ b/megaavr/libraries/Logic/src/Logic.h
@@ -4,24 +4,80 @@
 #include <Arduino.h>
 
 //Use in:: when working with logic inputs
+
+
 namespace in
 {
   enum input_t : uint8_t
   {
+#if defined(__AVR_ATmega808__) || defined(__AVR_ATmega1608__) || \
+    defined(__AVR_ATmega3208__) || defined(__AVR_ATmega4808__)|| \
+    defined(__AVR_ATmega809__) || defined(__AVR_ATmega1609__) || \
+    defined(__AVR_ATmega3209__) || defined(__AVR_ATmega4809__)
     masked       = 0x00,
     unused       = 0x00,
     disable      = 0x00,
     feedback     = 0x01,
     link         = 0x02,
+    event_0      = 0x03,
     event_a      = 0x03,
+    event_1      = 0x04,
     event_b      = 0x04,
-    input        = 0x05,
+    pin        = 0x05,
     ac           = 0x06,
-    input_pullup = 0x07,
     usart        = 0x08,
     spi          = 0x09,
     tca0         = 0x0A,
     tcb          = 0x0C,
+    input_pullup = 0x15,
+    input        = 0x25,
+    input_no_pullup= 0x25,
+#elif (defined __AVR_DA__)
+    masked       = 0x00,
+    unused       = 0x00,
+    disable      = 0x00,
+    feedback     = 0x01,
+    link         = 0x02,
+    event_0      = 0x03,
+    event_a      = 0x03,
+    event_1      = 0x04,
+    event_b      = 0x04,
+    pin          = 0x05,
+    ac           = 0x06,
+    zcd          = 0x07,
+    usart        = 0x08,
+    spi          = 0x09,
+    tca0         = 0x0A,
+    tca1         = 0x0B,
+    tcb          = 0x0C,
+    tcd          = 0x0D,
+    input_pullup = 0x15,
+    input        = 0x25,
+    input_no_pullup= 0x25,
+#else // megaTiny
+    masked       = 0x00,
+    unused       = 0x00,
+    disable      = 0x00,
+    feedback     = 0x01,
+    link         = 0x02,
+    event_0      = 0x03,
+    event_a      = 0x03,
+    event_1      = 0x04,
+    event_b      = 0x04,
+    pin          = 0x05,
+    ac0          = 0x06,
+    tcb0         = 0x07,
+    tca          = 0x08,
+    tcd0          = 0x09,
+    usart        = 0x0A,
+    spi          = 0x0B,
+    ac1          = 0x0C,
+    tcb1         = 0x0D,
+    ac2          = 0x0E,
+    input_pullup = 0x15,
+    input        = 0x25,
+    input_no_pullup= 0x25,
+    #endif
   };
 };
 
@@ -38,7 +94,7 @@ namespace out
     no_swap  = 0x00,
     pin_swap = 0x01,
   };
-}; 
+};
 
 // Use filter:: when working with logic output filter
 namespace filter
@@ -48,6 +104,29 @@ namespace filter
     disable      = 0x00,
     synchronizer = 0x01,
     filter       = 0x02,
+  };
+};
+
+// Use clocksource:: when working with logic clock source
+namespace clocksource
+{
+  enum clocksource_t : uint8_t
+  {
+    clk_per      = 0x00,
+    in2          = 0x01,
+    oschf        = 0x04,
+    osc32k       = 0x05,
+    osc1k        = 0x06,
+  };
+};
+
+// Use edgedetect:: when using edge detection with filter
+namespace edgedetect
+{
+  enum edgedet_t : uint8_t
+  {
+    disable      = 0x00,
+    enable       = 0x01
   };
 };
 
@@ -85,6 +164,8 @@ class Logic
     out::output_t output;
     out::pinswap_t output_swap;
     filter::filter_t filter;
+    clocksource::clocksource_t clocksource;
+    edgedetect::edgedet_t edgedetect;
     uint8_t truth;
     sequencer::sequencer_t sequencer;
 
@@ -107,6 +188,12 @@ extern Logic Logic2;
 #endif
 #if defined(CCL_TRUTH3)
 extern Logic Logic3;
+#endif
+#if defined(CCL_TRUTH4)
+extern Logic Logic4;
+#endif
+#if defined(CCL_TRUTH5)
+extern Logic Logic5;
 #endif
 
 #endif


### PR DESCRIPTION
The changes are no longer just relevant to non-megaAVR parts; features were added, bugs and a horriffic misfeature in the behavior of input as source (kept "input" behaving as it did, but added new "pin" to get what the behavior ought to be). Previously, it wasn't possible to have the pin be OUTPUT while using the value of that pin for the CCL.., but that's often your only (or perhaps, best) option to get LEVEL input from the code... software events don't latch, they're PULSE, and you can't change the LUT without stopping the whole CCL (thus introducing spikes on the outputs).... So having an OUTPUT pin be an input to CCL makes total sense.

Actually, it looks like you were already a version behind? You're missing one of the bugs too...