### PR TITLE
Fixed incorrect compiler error message

### DIFF
--- a/megaavr/cores/coreX-corefiles/UART0.cpp
+++ b/megaavr/cores/coreX-corefiles/UART0.cpp
@@ -51,7 +51,7 @@ ISR(HWSERIAL0_DRE_VECTOR)
   Serial._tx_data_empty_irq();
 }
 #else
-#error "Don't know what the Data Received interrupt vector is called for Serial"
+#error "Don't know what the Data Register Empty interrupt vector is called for Serial"
 #endif
 
 #if defined(HWSERIAL0)


### PR DESCRIPTION
Shows correct error message when HWSERIAL0_DRE_VECTOR is not defined.

I have verified and this copy/paste error is not present in the files for UART1 to UART3, only in this file.