### PR TITLE
Fixed fuse flashing in Nano Every configuration

### DIFF
--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -143,6 +143,16 @@ tools.avrdude.erase.params.verbose=-v
 tools.avrdude.erase.params.quiet=-q -q
 tools.avrdude.erase.pattern="{cmd.path}" "-C{config.path}" -v -p{build.mcu} -c{protocol} {program.extra_params} -e {bootloader.fuse0} {bootloader.fuse1} {bootloader.fuse2} {bootloader.fuse4} {bootloader.fuse5} {bootloader.fuse6} {bootloader.fuse7} {bootloader.fuse8} {bootloader.lock}
 
+tools.avrdude_nanoevery.bootloader.fuse0="-Ufuse0:w:{bootloader.WDTCFG}:m"
+tools.avrdude_nanoevery.bootloader.fuse1="-Ufuse1:w:{bootloader.BODCFG}:m"
+tools.avrdude_nanoevery.bootloader.fuse2="-Ufuse2:w:{bootloader.OSCCFG}:m"
+tools.avrdude_nanoevery.bootloader.fuse4="-Ufuse4:w:{bootloader.TCD0CFG}:m"
+tools.avrdude_nanoevery.bootloader.fuse5="-Ufuse5:w:{bootloader.SYSCFG0}:m"
+tools.avrdude_nanoevery.bootloader.fuse6="-Ufuse6:w:{bootloader.SYSCFG1}:m"
+tools.avrdude_nanoevery.bootloader.fuse7="-Ufuse7:w:{bootloader.APPEND}:m"
+tools.avrdude_nanoevery.bootloader.fuse8="-Ufuse8:w:{bootloader.BOOTEND}:m"
+tools.avrdude_nanoevery.bootloader.lock="-Ulock:w:{bootloader.LOCKBIT}:m"
+
 tools.avrdude.bootloader.fuse0="-Ufuse0:w:{bootloader.WDTCFG}:m"
 tools.avrdude.bootloader.fuse1="-Ufuse1:w:{bootloader.BODCFG}:m"
 tools.avrdude.bootloader.fuse2="-Ufuse2:w:{bootloader.OSCCFG}:m"


### PR DESCRIPTION
I noticed an issue with the current release of MegaCoreX while developing my own board with the following design choices: 

- Uses a SAMD11 for a combined UART+UPDI to USB interface, with JTAG2UPDI and the need for 1200bps touch (identical to the Arduino Nano)
- Uses an ATmega4809
- Uses Arduino Uno Wifi pinout and is attached to an onboard ESP32 Wi-Fi chipset

I modified the core in my own internal builds by duplicating the Nano Every's board definition and changed the `build.variant` to `uno-wifi` for that specific pinout, while still retaining the other properties for a SAMD11 based programmer (1200bps touch, JTAG2UPDI).

```
4809.menu.pinout.sstuinoii=SSTuino II
4809.menu.pinout.sstuinoii.build.variant=uno-wifi
4809.menu.pinout.sstuinoii.upload.tool=avrdude_nanoevery
4809.menu.pinout.sstuinoii.upload.use_1200bps_touch=true
4809.menu.pinout.sstuinoii.upload.protocol=jtag2updi
4809.menu.pinout.sstuinoii.program.extra_params=-P{serial.port} -e
4809.menu.pinout.sstuinoii.build.compat=
```

I started running into UART issues when I changed the board frequency from 20MHz to 16MHz (and by extension, all clock speeds that depend on the 16MHz oscillator). I tried to dump the fuses from the ATmega4809 and found out that the fuses were not burnt, meaning that while `F_CPU` was altered, the relevant fuse was never changed to reflect the correct frequency.

I dug around further and found that the `{bootloader.fuse0}` in platform.txt (and by extension, the other fuse and lock bits) were all blank, as `tools.avrdude_nanoevery` never had definitions for those variables. This commit fixes the issue by adding those variables, although there might be a more elegant solution than duplicating `tools.avrdude.bootloader.<insert fuse here>` into `tools.avrdude_nanoevery.bootloader.<insert fuse here>`. If others have more insights on this, please chime in as this is the first time I've modified platform.txt like this :)