### PR TITLE
Fix MegaCoreX library to support ArduinoModBus and ArduinoRS485

### DIFF
--- a/megaavr/cores/coreX-corefiles/api/Client.h
+++ b/megaavr/cores/coreX-corefiles/api/Client.h
@@ -21,7 +21,7 @@
 
 #include "IPAddress.h"
 #include "Stream.h"
-
+namespace arduino {
 class Client : public Stream
 {
  public:
@@ -41,3 +41,6 @@ class Client : public Stream
  protected:
   uint8_t *rawIPAddress(IPAddress &addr) { return addr.raw_address(); };
 };
+}
+using arduino::Client;
+

--- a/megaavr/cores/coreX-corefiles/api/IPAddress.h
+++ b/megaavr/cores/coreX-corefiles/api/IPAddress.h
@@ -24,6 +24,7 @@
 #include "Printable.h"
 #include "String.h"
 
+namespace arduino {
 // A class to make it easier to handle and pass around IP addresses
 
 class IPAddress : public Printable
@@ -75,3 +76,5 @@ class IPAddress : public Printable
 };
 
 extern const IPAddress INADDR_NONE;
+}
+using arduino::IPAddress;

--- a/megaavr/cores/coreX-corefiles/api/Udp.h
+++ b/megaavr/cores/coreX-corefiles/api/Udp.h
@@ -36,7 +36,7 @@
 
 #include "Stream.h"
 #include "IPAddress.h"
-
+namespace arduino {
 class UDP : public Stream
 {
  public:
@@ -84,3 +84,6 @@ class UDP : public Stream
  protected:
   uint8_t* rawIPAddress(IPAddress& addr) { return addr.raw_address(); };
 };
+}
+
+using arduino::UDP;

--- a/megaavr/variants/28pin-standard/pins_arduino.h
+++ b/megaavr/variants/28pin-standard/pins_arduino.h
@@ -302,6 +302,25 @@ const uint8_t digital_pin_to_timer[] = {
 
 #endif
 
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR       Serial
+#define SERIAL_PORT_HARDWARE      Serial1
+#define SERIAL_PORT_HARDWARE_OPEN Serial2
+
 void initVariant() __attribute__((weak));
 void initVariant() { }
 

--- a/megaavr/variants/32pin-standard/pins_arduino.h
+++ b/megaavr/variants/32pin-standard/pins_arduino.h
@@ -340,6 +340,25 @@ const uint8_t digital_pin_to_timer[] = {
 
 #endif
 
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR       Serial
+#define SERIAL_PORT_HARDWARE      Serial1
+#define SERIAL_PORT_HARDWARE_OPEN Serial2
+
 void initVariant() __attribute__((weak));
 void initVariant() { }
 

--- a/megaavr/variants/40pin-standard/pins_arduino.h
+++ b/megaavr/variants/40pin-standard/pins_arduino.h
@@ -378,6 +378,26 @@ const uint8_t digital_pin_to_timer[] = {
 
 #endif
 
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR       Serial
+#define SERIAL_PORT_HARDWARE      Serial1
+#define SERIAL_PORT_HARDWARE_OPEN Serial2
+
+
 void initVariant() __attribute__((weak));
 void initVariant()
 {

--- a/megaavr/variants/48pin-standard/pins_arduino.h
+++ b/megaavr/variants/48pin-standard/pins_arduino.h
@@ -446,6 +446,26 @@ const uint8_t digital_pin_to_timer[] = {
 
 #endif
 
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR        Serial
+#define SERIAL_PORT_HARDWARE       Serial1
+#define SERIAL_PORT_HARDWARE_OPEN  Serial2
+#define SERIAL_PORT_HARDWARE_OPEN2 Serial3
+
 void initVariant() __attribute__((weak));
 void initVariant() { }
 


### PR DESCRIPTION
This is a fix for #192 . 

Arduino's modbus library is written assuming that the ArduinoCore-API is new enough that there is an arduino namespace. The version inside MegaCoreX is an older version of the api and does not have this. This pull request adds the _minimal_ number of classes in the api to the arduino namespace to allow ArduinoModbus to compile. 

The second change is related, the ArduinoRS485 library is written with the assumption that the macro SERIAL_PORT_HARDWARE is available from the board's variant header. This assumption was violated for the standard 28/32/40/48 pin variants. This pull request introduces these missing macros for libraries such as ArduinoRS485 so that they can compile successfully. I tried using what I viewed as sane defaults. 
