### PR TITLE
Fix IPAddress further so that the Ethernet library will work again

### DIFF
--- a/megaavr/cores/coreX-corefiles/api/IPAddress.h
+++ b/megaavr/cores/coreX-corefiles/api/IPAddress.h
@@ -24,6 +24,10 @@
 #include "Printable.h"
 #include "String.h"
 
+class EthernetClass;
+class DhcpClass;
+class DNSClient;
+
 namespace arduino {
 // A class to make it easier to handle and pass around IP addresses
 
@@ -67,12 +71,13 @@ class IPAddress : public Printable
 
   virtual size_t printTo(Print& p) const;
 
-  friend class EthernetClass;
   friend class UDP;
   friend class Client;
   friend class Server;
-  friend class DhcpClass;
-  friend class DNSClient;
+
+  friend ::EthernetClass;
+  friend ::DhcpClass;
+  friend ::DNSClient;
 };
 
 extern const IPAddress INADDR_NONE;


### PR DESCRIPTION
This should fix #201 
This is my fault, I applied the minimal number of changes necessary to get ArduinoModBus to compile. Apparently, in the ArudinoCore-API they have to forward declare several classes outside the arduino namespace to allow EthernetClass, DhcpClass, and DNSClient to be friends. 

I have already tested this change manually using the TelentClient example and compilation is once again successful.