### PR TITLE
Move INADDR_NONE out of the arduino namespace to not break the Ethernet library

### DIFF
--- a/megaavr/cores/coreX-corefiles/api/IPAddress.h
+++ b/megaavr/cores/coreX-corefiles/api/IPAddress.h
@@ -80,6 +80,7 @@ class IPAddress : public Printable
   friend ::DNSClient;
 };
 
-extern const IPAddress INADDR_NONE;
 }
 using arduino::IPAddress;
+
+extern const IPAddress INADDR_NONE;


### PR DESCRIPTION
When I grafted the newer arduino namespace in for Modbus library compatibility, I introduced a very subtle problem where constant objects defined in the arduino namespace had to be fully qualified.

I suspect that the changes that arduino made to their API in the versions since 1.0.0 somehow allowed for unqualified name resolution.

This pull request fixes #207 

NOTE: At some point, it may be very smart to synchronize with a newer version of the ArduinoCore-API. 