### PR TITLE
Ready to go

### DIFF
--- a/megaavr/cores/coreX-corefiles/api/Common.h
+++ b/megaavr/cores/coreX-corefiles/api/Common.h
@@ -92,6 +92,14 @@ void detachInterrupt(pin_size_t interruptNumber);
 void setup(void);
 void loop(void);
 
+// Constant checks error handler
+void badArg(const char*) __attribute__((error("")));
+inline __attribute__((always_inline)) void check_constant_pin(pin_size_t pin)
+{
+  if(!__builtin_constant_p(pin))
+    badArg("Digital pin must be a constant");
+}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/megaavr/cores/coreX-corefiles/wiring_digital.c
+++ b/megaavr/cores/coreX-corefiles/wiring_digital.c
@@ -205,7 +205,7 @@ void digitalWrite(uint8_t pin, uint8_t val)
 inline __attribute__((always_inline)) void digitalWriteFast(uint8_t pin, uint8_t val)
 {
   // Make sure pin is constant and know at compile time
-  static_assert(__builtin_constant_p(pin), "Digital pin must be a constant");
+  check_constant_pin(pin);
 
   // Mega-0, Tiny-1 style IOPORTs
   // Assumes VPORTs exist starting at 0 for each PORT structure
@@ -249,8 +249,8 @@ uint8_t digitalRead(uint8_t pin)
 
 inline __attribute__((always_inline)) uint8_t digitalReadFast(uint8_t pin)
 {
-  // Make sure pin is constant and know at compile time
-  static_assert(__builtin_constant_p(pin), "Digital pin must be a constant");
+  // Make sure pin is constant and known at compile time
+  check_constant_pin(pin);
 
   // Mega-0, Tiny-1 style IOPORTs
   // Assumes VPORTs exist starting at 0 for each PORT structure

--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -6,15 +6,15 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=MegaCoreX
-version=1.2.0
+version=1.2.0-pre5
 
 # AVR compile variables
 # ---------------------
 
 # Optimization flags for debugging
-compiler.optimization_flags=-Os -ggdb3 -flto -DNDEBUG
-compiler.optimization_flags.release=-Os -ggdb3 -flto -DNDEBUG
-compiler.optimization_flags.debug=-Og -ggdb3 -DDEBUG -fno-lto
+compiler.optimization_flags=-Os -ggdb3 -DNDEBUG 
+compiler.optimization_flags.release=-Os -ggdb3 -DNDEBUG 
+compiler.optimization_flags.debug=-Og -ggdb3 -DDEBUG 
 
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w
@@ -25,12 +25,12 @@ compiler.warning_flags.all=-Wall -Wextra
 # Default "compiler.path" is correct, change only if you want to override the initial value
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
-compiler.c.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD  -fno-fat-lto-objects
-compiler.c.elf.flags={compiler.warning_flags} {compiler.optimization_flags} -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start}
+compiler.c.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects
+compiler.c.elf.flags={compiler.warning_flags} {compiler.optimization_flags} -flto -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start}
 compiler.c.elf.cmd=avr-gcc
-compiler.S.flags=-c -x assembler-with-cpp {compiler.optimization_flags} -MMD
+compiler.S.flags=-c -x assembler-with-cpp {compiler.optimization_flags} -flto -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++17 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD 
+compiler.cpp.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++17 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
@@ -177,13 +177,15 @@ debug.cortex-debug.custom.gdbPath={debug.toolchain.path}/avr-gdb
 debug.cortex-debug.custom.overrideGDBServerStartedRegex=Listening on port \d+ for gdb connection
 debug.cortex-debug.custom.objdumpPath={runtime.tools.avr-gcc.path}/bin/avr-objdump
 debug.cortex-debug.custom.serverArgs.0=-s
-# The nop should be the serverArgs.1 because the programmer simavr may change that!
 debug.cortex-debug.custom.serverArgs.1=nop
-debug.cortex-debug.custom.serverArgs.2=-d
+debug.cortex-debug.custom.serverArgs.2=--device
 debug.cortex-debug.custom.serverArgs.3={build.mcu}
 debug.cortex-debug.custom.serverArgs.4=--manage
 debug.cortex-debug.custom.serverArgs.5=all
 debug.cortex-debug.custom.serverArgs.6=--F_CPU
 debug.cortex-debug.custom.serverArgs.7={build.f_cpu}
+debug.cortex-debug.custom.serverArgs.8=--elf-file
+debug.cortex-debug.custom.serverArgs.9={debug.executable}
+
 debug.cortex-debug.custom.runToEntryPoint=main
 debug.svd_file={debug.toolchain.path}/pyavrocd-util/svd/{build.mcu}.svd

--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -6,15 +6,15 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=MegaCoreX
-version=1.2.0-pre5
+version=1.2.0
 
 # AVR compile variables
 # ---------------------
 
 # Optimization flags for debugging
-compiler.optimization_flags=-Os -ggdb3 -DNDEBUG 
-compiler.optimization_flags.release=-Os -ggdb3 -DNDEBUG 
-compiler.optimization_flags.debug=-Og -ggdb3 -DDEBUG 
+compiler.optimization_flags=-Os -ggdb3 -DNDEBUG
+compiler.optimization_flags.release=-Os -ggdb3 -DNDEBUG
+compiler.optimization_flags.debug=-Og -ggdb3 -DDEBUG
 
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w


### PR DESCRIPTION
As I mentioned https://github.com/MCUdude/MegaCoreX/issues/215#issuecomment-4482749185, it is hopeless to try to use the megaavr cores without LTO. I changed, therefore, a few things back, and debugging will now take place with LTO enabled. I will soon start to explore whether newer GCC versions will be better in keeping debug information when LTO is enabled.

Please note that you also need to include the most recent version of the avrocd-tools. I added a mechanism to detect whether an ELF file was linked using -mrelax and you can now use the debugger even when you installed a bootloader.  